### PR TITLE
Fix TypeScript errors in test files

### DIFF
--- a/frontend/tests/components/concepts/ConceptDetail.test.tsx
+++ b/frontend/tests/components/concepts/ConceptDetail.test.tsx
@@ -20,6 +20,7 @@ vi.mock("../../../src/components/common/ConfirmDialog", () => ({
 
 const mockConcept: Concept = {
   id: "concept-1",
+  scheme_id: "scheme-1",
   pref_label: "Test Concept",
   identifier: "001",
   definition: "Test definition",
@@ -27,7 +28,6 @@ const mockConcept: Concept = {
   alt_labels: ["Alternative 1", "Alternative 2"],
   uri: "http://example.org/concepts/001",
   broader: [],
-  narrower: [],
   related: [],
   created_at: "2024-01-01T00:00:00Z",
   updated_at: "2024-01-02T00:00:00Z",

--- a/frontend/tests/components/workspace/ConceptPane.test.tsx
+++ b/frontend/tests/components/workspace/ConceptPane.test.tsx
@@ -27,7 +27,6 @@ const mockConcept: Concept = {
 };
 
 describe("ConceptPane", () => {
-  const mockOnEdit = vi.fn();
   const mockOnDelete = vi.fn();
   const mockOnRefresh = vi.fn();
 
@@ -40,7 +39,6 @@ describe("ConceptPane", () => {
   it("shows empty state when no concept is selected", () => {
     render(
       <ConceptPane
-        onEdit={mockOnEdit}
         onDelete={mockOnDelete}
         onRefresh={mockOnRefresh}
       />
@@ -56,7 +54,6 @@ describe("ConceptPane", () => {
 
     render(
       <ConceptPane
-        onEdit={mockOnEdit}
         onDelete={mockOnDelete}
         onRefresh={mockOnRefresh}
       />


### PR DESCRIPTION
Update mock objects to match current type definitions: remove 'narrower' from Concept type and 'onEdit' from ConceptPaneProps.

https://claude.ai/code/session_011uqdbzuoVMVJVhmGJE9ZHg