### PR TITLE
Fix broken auth on import

### DIFF
--- a/frontend/src/api/schemes.ts
+++ b/frontend/src/api/schemes.ts
@@ -1,4 +1,4 @@
-import { api, ApiError } from "./client";
+import { api } from "./client";
 import { API_BASE } from "../config";
 import type {
   ConceptScheme,
@@ -43,31 +43,14 @@ export function getExportUrl(schemeId: string, format: ExportFormat): string {
   return `${API_BASE}/schemes/${schemeId}/export?format=${format}`;
 }
 
-async function importRequest<T>(
+function importRequest<T>(
   projectId: string,
   file: File,
   dryRun: boolean
 ): Promise<T> {
   const formData = new FormData();
   formData.append("file", file);
-
-  const response = await fetch(
-    `${API_BASE}/projects/${projectId}/import?dry_run=${dryRun}`,
-    {
-      method: "POST",
-      body: formData,
-    }
-  );
-
-  if (!response.ok) {
-    const error = await response.json().catch(() => ({}));
-    throw new ApiError(
-      response.status,
-      error.detail || `Import failed: ${response.status}`
-    );
-  }
-
-  return response.json();
+  return api.postForm<T>(`/projects/${projectId}/import?dry_run=${dryRun}`, formData);
 }
 
 export const schemesApi = {

--- a/frontend/tests/api/schemes.test.ts
+++ b/frontend/tests/api/schemes.test.ts
@@ -1,5 +1,18 @@
-import { describe, it, expect } from "vitest";
-import { getExportUrl } from "../../src/api/schemes";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { getExportUrl, schemesApi } from "../../src/api/schemes";
+
+// Mock the auth module
+vi.mock("../../src/api/auth", () => ({
+  getToken: vi.fn(),
+}));
+
+// Mock the auth state module
+vi.mock("../../src/state/auth", () => ({
+  clearAuth: vi.fn(),
+}));
+
+import { getToken } from "../../src/api/auth";
+import { clearAuth } from "../../src/state/auth";
 
 describe("getExportUrl", () => {
   const schemeId = "abc-123";
@@ -23,5 +36,61 @@ describe("getExportUrl", () => {
     const uuid = "550e8400-e29b-41d4-a716-446655440000";
     const url = getExportUrl(uuid, "ttl");
     expect(url).toBe(`/api/schemes/${uuid}/export?format=ttl`);
+  });
+});
+
+describe("schemesApi.previewImport", () => {
+  const mockFetch = vi.fn();
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    global.fetch = mockFetch;
+    vi.mocked(getToken).mockResolvedValue("test-token");
+    vi.mocked(clearAuth).mockClear();
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    vi.clearAllMocks();
+  });
+
+  it("includes Authorization header with Bearer token", async () => {
+    const mockPreview = {
+      valid: true,
+      schemes: [],
+      total_concepts_count: 0,
+      total_relationships_count: 0,
+      errors: [],
+    };
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(mockPreview),
+    });
+
+    const file = new File(["test content"], "test.ttl", {
+      type: "text/turtle",
+    });
+    await schemesApi.previewImport("project-123", file);
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const [url, options] = mockFetch.mock.calls[0];
+    expect(url).toBe("/api/projects/project-123/import?dry_run=true");
+    expect(options.method).toBe("POST");
+    expect(options.headers?.Authorization).toBe("Bearer test-token");
+  });
+
+  it("calls clearAuth on 401 response", async () => {
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 401,
+      json: () => Promise.resolve({ detail: "Not authenticated" }),
+    });
+
+    const file = new File(["test"], "test.ttl");
+
+    await expect(schemesApi.previewImport("project-123", file)).rejects.toThrow(
+      "Session expired"
+    );
+    expect(clearAuth).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
When we added auth, it got missed for import because it wasn't using the API client due to it being a form rather than a normal fetch. This has been resolved!