### PR TITLE
Add property management UI (#26)

### DIFF
--- a/frontend/src/api/properties.ts
+++ b/frontend/src/api/properties.ts
@@ -1,0 +1,26 @@
+import { api } from "./client";
+import type {
+  Property,
+  PropertyCreate,
+  PropertyUpdate,
+  CoreOntologyResponse,
+} from "../types/models";
+
+export const propertiesApi = {
+  listForProject: (projectId: string) =>
+    api.get<Property[]>(`/projects/${projectId}/properties`),
+
+  get: (id: string) => api.get<Property>(`/properties/${id}`),
+
+  create: (projectId: string, data: PropertyCreate) =>
+    api.post<Property>(`/projects/${projectId}/properties`, data),
+
+  update: (id: string, data: PropertyUpdate) =>
+    api.put<Property>(`/properties/${id}`, data),
+
+  delete: (id: string) => api.delete(`/properties/${id}`),
+};
+
+export const ontologyApi = {
+  get: () => api.get<CoreOntologyResponse>("/ontology"),
+};

--- a/frontend/src/components/common/Button.tsx
+++ b/frontend/src/components/common/Button.tsx
@@ -7,6 +7,7 @@ interface ButtonProps {
   size?: "sm" | "md" | "lg";
   type?: "button" | "submit";
   disabled?: boolean;
+  "aria-label"?: string;
   onClick?: (e: JSX.TargetedMouseEvent<HTMLButtonElement>) => void;
 }
 
@@ -16,6 +17,7 @@ export function Button({
   size = "md",
   type = "button",
   disabled = false,
+  "aria-label": ariaLabel,
   onClick,
 }: ButtonProps) {
   return (
@@ -23,6 +25,7 @@ export function Button({
       type={type}
       class={`btn btn--${variant} btn--${size}`}
       disabled={disabled}
+      aria-label={ariaLabel}
       onClick={onClick}
     >
       {children}

--- a/frontend/src/components/common/ConfirmDialog.css
+++ b/frontend/src/components/common/ConfirmDialog.css
@@ -1,6 +1,22 @@
+.confirm-dialog--danger {
+  text-align: center;
+}
+
+.confirm-dialog__icon {
+  display: flex;
+  justify-content: center;
+  margin-bottom: var(--spacing-md);
+  color: var(--color-danger);
+}
+
 .confirm-dialog__message {
-  color: var(--color-text-secondary);
+  color: var(--color-text);
   margin-bottom: var(--spacing-lg);
+  font-size: var(--font-size-md);
+}
+
+.confirm-dialog--danger .confirm-dialog__message {
+  font-weight: 500;
 }
 
 .confirm-dialog__actions {

--- a/frontend/src/components/common/ConfirmDialog.tsx
+++ b/frontend/src/components/common/ConfirmDialog.tsx
@@ -25,7 +25,16 @@ export function ConfirmDialog({
 }: ConfirmDialogProps) {
   return (
     <Modal isOpen={isOpen} title={title} onClose={onCancel}>
-      <div class="confirm-dialog">
+      <div class={`confirm-dialog ${variant === "danger" ? "confirm-dialog--danger" : ""}`}>
+        {variant === "danger" && (
+          <div class="confirm-dialog__icon" aria-hidden="true">
+            <svg width="40" height="40" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z" />
+              <line x1="12" y1="9" x2="12" y2="13" />
+              <line x1="12" y1="17" x2="12.01" y2="17" />
+            </svg>
+          </div>
+        )}
         <p class="confirm-dialog__message">{message}</p>
         <div class="confirm-dialog__actions">
           <Button variant="secondary" onClick={onCancel}>

--- a/frontend/src/components/properties/PropertiesPane.css
+++ b/frontend/src/components/properties/PropertiesPane.css
@@ -1,0 +1,99 @@
+.properties-pane {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  padding: var(--spacing-lg);
+  overflow: auto;
+}
+
+.properties-pane__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: var(--spacing-lg);
+}
+
+.properties-pane__title {
+  font-size: var(--font-size-lg);
+  font-weight: 600;
+  margin: 0;
+}
+
+.properties-pane__error {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  flex: 1;
+  font-size: var(--font-size-sm);
+  text-align: center;
+  gap: var(--spacing-xs);
+  padding: var(--spacing-lg);
+  border: 2px solid var(--color-text);
+  border-radius: var(--radius-md);
+  margin: var(--spacing-lg);
+}
+
+.properties-pane__error p {
+  margin: 0;
+}
+
+.properties-pane__empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  flex: 1;
+  color: var(--color-text-muted);
+  font-size: var(--font-size-sm);
+  text-align: center;
+  gap: var(--spacing-xs);
+}
+
+.properties-pane__empty p {
+  margin: 0;
+}
+
+.properties-pane__table-wrapper {
+  overflow-x: auto;
+}
+
+.properties-pane__table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: var(--font-size-sm);
+}
+
+.properties-pane__table th {
+  text-align: left;
+  padding: var(--spacing-sm) var(--spacing-md);
+  border-bottom: 2px solid var(--color-border);
+  font-weight: 600;
+  color: var(--color-text-muted);
+  white-space: nowrap;
+}
+
+.properties-pane__table td {
+  padding: var(--spacing-sm) var(--spacing-md);
+  border-bottom: 1px solid var(--color-border);
+  vertical-align: middle;
+}
+
+.properties-pane__table tbody tr:hover {
+  background: var(--color-bg-hover);
+}
+
+.properties-pane__cell--label {
+  font-weight: 500;
+}
+
+.properties-pane__cell--identifier code {
+  font-size: var(--font-size-xs);
+  background: var(--color-bg-secondary);
+  padding: 2px var(--spacing-xs);
+  border-radius: var(--radius-sm);
+}
+
+.properties-pane__cell--actions {
+  white-space: nowrap;
+}

--- a/frontend/src/components/properties/PropertiesPane.tsx
+++ b/frontend/src/components/properties/PropertiesPane.tsx
@@ -1,0 +1,100 @@
+import { Button } from "../common/Button";
+import type { Property, OntologyClass } from "../../types/models";
+import "./PropertiesPane.css";
+
+interface PropertiesPaneProps {
+  projectId: string;
+  properties: Property[];
+  schemes: { id: string; title: string }[];
+  ontologyClasses: OntologyClass[];
+  loading?: boolean;
+  error?: string | null;
+  onCreate: () => void;
+  onEdit: (property: Property) => void;
+  onDelete: (property: Property) => void;
+}
+
+export function PropertiesPane({
+  properties,
+  ontologyClasses,
+  loading,
+  error,
+  onCreate,
+  onEdit,
+  onDelete,
+}: PropertiesPaneProps) {
+  const classLabelMap = new Map(ontologyClasses.map((c) => [c.uri, c.label]));
+
+  function getDomainLabel(uri: string): string {
+    return classLabelMap.get(uri) ?? uri;
+  }
+
+  function getRangeDisplay(prop: Property): string {
+    if (prop.range_scheme) return prop.range_scheme.title;
+    if (prop.range_datatype) return prop.range_datatype;
+    return "—";
+  }
+
+  return (
+    <div class="properties-pane">
+      <div class="properties-pane__header">
+        <h2 class="properties-pane__title">Properties</h2>
+        <Button onClick={onCreate}>New Property</Button>
+      </div>
+
+      {error ? (
+        <div class="properties-pane__error" role="alert">
+          <p>Failed to load properties.</p>
+          <p>{error}</p>
+        </div>
+      ) : loading ? (
+        <div class="properties-pane__empty">
+          <p>Loading properties...</p>
+        </div>
+      ) : properties.length === 0 ? (
+        <div class="properties-pane__empty">
+          <p>No properties defined yet.</p>
+          <p>Properties link vocabulary classes to concept schemes or datatypes.</p>
+        </div>
+      ) : (
+        <div class="properties-pane__table-wrapper">
+          <table class="properties-pane__table">
+            <thead>
+              <tr>
+                <th scope="col">Label</th>
+                <th scope="col">Identifier</th>
+                <th scope="col">Applies to</th>
+                <th scope="col">Range</th>
+                <th scope="col">Cardinality</th>
+                <th scope="col">Required</th>
+                <th scope="col">Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {properties.map((prop) => (
+                <tr key={prop.id}>
+                  <td class="properties-pane__cell--label">{prop.label}</td>
+                  <td class="properties-pane__cell--identifier">
+                    <code>{prop.identifier}</code>
+                  </td>
+                  <td>{getDomainLabel(prop.domain_class)}</td>
+                  <td>{getRangeDisplay(prop)}</td>
+                  <td>{prop.cardinality}</td>
+                  <td>{prop.required ? "Yes" : "No"}</td>
+                  <td class="properties-pane__cell--actions">
+                    <Button variant="ghost" size="sm" onClick={() => onEdit(prop)} aria-label={`Edit ${prop.label}`}>
+                      Edit
+                    </Button>
+                    <Button variant="ghost" size="sm" onClick={() => onDelete(prop)} aria-label={`Delete ${prop.label}`}>
+                      Delete
+                    </Button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/properties/PropertyForm.css
+++ b/frontend/src/components/properties/PropertyForm.css
@@ -1,0 +1,77 @@
+.property-form {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-md);
+}
+
+.property-form__error {
+  padding: var(--spacing-sm) var(--spacing-md);
+  background: #fef2f2;
+  color: #dc2626;
+  border-radius: var(--radius-md);
+  font-size: var(--font-size-sm);
+}
+
+.property-form__fieldset {
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  padding: var(--spacing-sm) var(--spacing-md) var(--spacing-md);
+  margin: 0;
+}
+
+.property-form__legend {
+  font-size: var(--font-size-sm);
+  font-weight: 500;
+  padding: 0 var(--spacing-xs);
+  color: var(--color-text);
+}
+
+.property-form__range-toggle {
+  display: flex;
+  gap: var(--spacing-lg);
+  margin-bottom: var(--spacing-sm);
+}
+
+.property-form__radio-label {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-xs);
+  font-size: var(--font-size-sm);
+  cursor: pointer;
+}
+
+.property-form__radio-label input[disabled] {
+  cursor: not-allowed;
+}
+
+.property-form__hint {
+  color: var(--color-text-muted);
+  font-size: var(--font-size-xs);
+  font-style: italic;
+  margin-left: var(--spacing-xs);
+}
+
+.property-form__checkbox-label {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-xs);
+  font-size: var(--font-size-sm);
+  cursor: pointer;
+}
+
+.property-form__actions {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: var(--spacing-sm);
+  padding-top: var(--spacing-sm);
+}
+
+.property-form__missing {
+  font-size: var(--font-size-sm);
+  font-weight: 500;
+  padding: var(--spacing-sm) var(--spacing-md);
+  border: 2px solid var(--color-text);
+  border-radius: var(--radius-md);
+  color: var(--color-text);
+}

--- a/frontend/src/components/properties/PropertyForm.tsx
+++ b/frontend/src/components/properties/PropertyForm.tsx
@@ -1,0 +1,381 @@
+import { useState, useEffect } from "preact/hooks";
+import { Input } from "../common/Input";
+import { Button } from "../common/Button";
+import { propertiesApi } from "../../api/properties";
+import { ApiError } from "../../api/client";
+import type { Property, ConceptScheme, OntologyClass } from "../../types/models";
+import "./PropertyForm.css";
+
+const ALLOWED_DATATYPES = [
+  "xsd:string",
+  "xsd:integer",
+  "xsd:decimal",
+  "xsd:boolean",
+  "xsd:date",
+  "xsd:dateTime",
+  "xsd:anyURI",
+];
+
+const IDENTIFIER_PATTERN = /^[a-zA-Z][a-zA-Z0-9_-]*$/;
+
+export function labelToIdentifier(label: string): string {
+  let slug = label
+    .replace(/[^\x20-\x7E]/g, "") // strip non-ASCII
+    .toLowerCase()
+    .replace(/[^a-z0-9\s-]/g, "") // strip punctuation
+    .trim()
+    .replace(/[\s-]+/g, "-") // collapse whitespace/hyphens
+    .replace(/^-+|-+$/g, ""); // trim leading/trailing hyphens
+
+  if (!slug) return "";
+
+  if (/^[0-9]/.test(slug)) {
+    slug = `prop-${slug}`;
+  }
+
+  return slug;
+}
+
+interface PropertyFormProps {
+  projectId: string;
+  schemes: ConceptScheme[];
+  ontologyClasses: OntologyClass[];
+  property?: Property | null;
+  onSuccess: () => void;
+  onCancel: () => void;
+}
+
+type RangeType = "scheme" | "datatype";
+
+export function PropertyForm({
+  projectId,
+  schemes,
+  ontologyClasses,
+  property,
+  onSuccess,
+  onCancel,
+}: PropertyFormProps) {
+  const isEdit = !!property;
+
+  const [label, setLabel] = useState(property?.label ?? "");
+  const [identifier, setIdentifier] = useState(property?.identifier ?? "");
+  const [identifierTouched, setIdentifierTouched] = useState(isEdit);
+  const [description, setDescription] = useState(property?.description ?? "");
+  const [domainClass, setDomainClass] = useState(property?.domain_class ?? "");
+  const [rangeType, setRangeType] = useState<RangeType>(() => {
+    if (property?.range_datatype) return "datatype";
+    if (property?.range_scheme_id) return "scheme";
+    return schemes.length > 0 ? "scheme" : "datatype";
+  });
+  const [rangeSchemeId, setRangeSchemeId] = useState(property?.range_scheme_id ?? "");
+  const [rangeDatatype, setRangeDatatype] = useState(property?.range_datatype ?? "");
+  const [cardinality, setCardinality] = useState<"single" | "multiple">(
+    property?.cardinality ?? "single"
+  );
+  const [required, setRequired] = useState(property?.required ?? false);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [identifierError, setIdentifierError] = useState<string | null>(null);
+
+  // Sync form state when property prop changes
+  useEffect(() => {
+    setLabel(property?.label ?? "");
+    setIdentifier(property?.identifier ?? "");
+    setIdentifierTouched(!!property);
+    setDescription(property?.description ?? "");
+    setDomainClass(property?.domain_class ?? "");
+    if (property?.range_datatype) setRangeType("datatype");
+    else if (property?.range_scheme_id) setRangeType("scheme");
+    else setRangeType(schemes.length > 0 ? "scheme" : "datatype");
+    setRangeSchemeId(property?.range_scheme_id ?? "");
+    setRangeDatatype(property?.range_datatype ?? "");
+    setCardinality(property?.cardinality ?? "single");
+    setRequired(property?.required ?? false);
+    setError(null);
+    setIdentifierError(null);
+  }, [property]);
+
+  function handleLabelChange(value: string) {
+    setLabel(value);
+    if (!identifierTouched) {
+      const generated = labelToIdentifier(value);
+      setIdentifier(generated);
+      validateIdentifier(generated);
+    }
+  }
+
+  function handleIdentifierChange(value: string) {
+    setIdentifierTouched(true);
+    setIdentifier(value);
+    validateIdentifier(value);
+  }
+
+  function validateIdentifier(value: string) {
+    if (value && !IDENTIFIER_PATTERN.test(value)) {
+      setIdentifierError("Must start with a letter and contain only letters, numbers, hyphens, or underscores");
+    } else {
+      setIdentifierError(null);
+    }
+  }
+
+  function handleRangeTypeChange(type: RangeType) {
+    setRangeType(type);
+    if (type === "scheme") {
+      setRangeDatatype("");
+    } else {
+      setRangeSchemeId("");
+    }
+  }
+
+  const hasSchemes = schemes.length > 0;
+  const rangeValid =
+    (rangeType === "scheme" && rangeSchemeId) ||
+    (rangeType === "datatype" && rangeDatatype);
+
+  function getMissingFields(): string[] {
+    const missing: string[] = [];
+    if (!label.trim()) missing.push("Label");
+    if (!identifier.trim()) missing.push("Identifier");
+    else if (identifierError) missing.push("Identifier (invalid)");
+    if (!domainClass) missing.push("Applies to");
+    if (!rangeValid) missing.push(rangeType === "scheme" ? "Scheme selection" : "Datatype selection");
+    return missing;
+  }
+
+  const hasChanges = !isEdit || (
+    label !== (property?.label ?? "") ||
+    description !== (property?.description ?? "") ||
+    domainClass !== (property?.domain_class ?? "") ||
+    rangeSchemeId !== (property?.range_scheme_id ?? "") ||
+    rangeDatatype !== (property?.range_datatype ?? "") ||
+    cardinality !== (property?.cardinality ?? "single") ||
+    required !== (property?.required ?? false)
+  );
+
+  const missingFields = getMissingFields();
+  const canSubmit = missingFields.length === 0 && hasChanges && !loading;
+
+  async function handleSubmit(e: Event) {
+    e.preventDefault();
+    setLoading(true);
+    setError(null);
+
+    try {
+      if (isEdit) {
+        await propertiesApi.update(property!.id, {
+          label,
+          description: description || null,
+          domain_class: domainClass,
+          range_scheme_id: rangeType === "scheme" ? rangeSchemeId : null,
+          range_datatype: rangeType === "datatype" ? rangeDatatype : null,
+          cardinality,
+          required,
+        });
+      } else {
+        await propertiesApi.create(projectId, {
+          identifier,
+          label,
+          description: description || null,
+          domain_class: domainClass,
+          range_scheme_id: rangeType === "scheme" ? rangeSchemeId : null,
+          range_datatype: rangeType === "datatype" ? rangeDatatype : null,
+          cardinality,
+          required,
+        });
+      }
+      onSuccess();
+    } catch (err) {
+      if (err instanceof ApiError) {
+        if (err.status === 409) {
+          setError("A property with this identifier already exists");
+        } else {
+          setError(err.message);
+        }
+      } else {
+        setError(err instanceof Error ? err.message : "An error occurred");
+      }
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <form class="property-form" onSubmit={handleSubmit} role="form">
+      {error && <div class="property-form__error" role="alert">{error}</div>}
+
+      <Input
+        label="Label"
+        name="label"
+        value={label}
+        placeholder="Display name for this property"
+        required
+        onChange={handleLabelChange}
+      />
+
+      <div class={`input-field ${identifierError ? "input-field--error" : ""}`}>
+        <label class="input-field__label" for="input-identifier">
+          Identifier<span class="input-field__required">*</span>
+        </label>
+        <input
+          id="input-identifier"
+          name="identifier"
+          type="text"
+          class="input-field__input"
+          value={identifier}
+          placeholder="auto-generated-from-label"
+          readOnly={isEdit}
+          aria-required="true"
+          aria-invalid={!!identifierError}
+          aria-describedby={identifierError ? "identifier-error" : undefined}
+          onInput={(e) => handleIdentifierChange(e.currentTarget.value)}
+        />
+        {identifierError && (
+          <span id="identifier-error" class="input-field__error" role="alert">{identifierError}</span>
+        )}
+      </div>
+
+      <Input
+        label="Description"
+        name="description"
+        value={description}
+        placeholder="Optional description"
+        multiline
+        onChange={setDescription}
+      />
+
+      <div class="input-field">
+        <label class="input-field__label" for="input-domain-class">
+          Applies to<span class="input-field__required">*</span>
+        </label>
+        <select
+          id="input-domain-class"
+          class="input-field__input"
+          value={domainClass}
+          aria-required="true"
+          onChange={(e) => setDomainClass(e.currentTarget.value)}
+        >
+          <option value="">Select a class...</option>
+          {ontologyClasses.map((cls) => (
+            <option key={cls.uri} value={cls.uri}>
+              {cls.label}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      <fieldset class="property-form__fieldset">
+        <legend class="property-form__legend">Range</legend>
+        <div class="property-form__range-toggle">
+          <label class="property-form__radio-label">
+            <input
+              type="radio"
+              name="range-type"
+              value="scheme"
+              checked={rangeType === "scheme"}
+              disabled={!hasSchemes}
+              onChange={() => handleRangeTypeChange("scheme")}
+            />
+            Concept Scheme
+            {!hasSchemes && (
+              <span class="property-form__hint">Create a scheme first</span>
+            )}
+          </label>
+          <label class="property-form__radio-label">
+            <input
+              type="radio"
+              name="range-type"
+              value="datatype"
+              checked={rangeType === "datatype"}
+              onChange={() => handleRangeTypeChange("datatype")}
+            />
+            Datatype
+          </label>
+        </div>
+
+        {rangeType === "scheme" && hasSchemes && (
+          <select
+            class="input-field__input"
+            value={rangeSchemeId}
+            onChange={(e) => setRangeSchemeId(e.currentTarget.value)}
+            aria-label="Scheme select"
+          >
+            <option value="">Select a scheme...</option>
+            {schemes.map((s) => (
+              <option key={s.id} value={s.id}>
+                {s.title}
+              </option>
+            ))}
+          </select>
+        )}
+
+        {rangeType === "datatype" && (
+          <select
+            class="input-field__input"
+            value={rangeDatatype}
+            onChange={(e) => setRangeDatatype(e.currentTarget.value)}
+            aria-label="Datatype select"
+          >
+            <option value="">Select a datatype...</option>
+            {ALLOWED_DATATYPES.map((dt) => (
+              <option key={dt} value={dt}>
+                {dt}
+              </option>
+            ))}
+          </select>
+        )}
+      </fieldset>
+
+      <fieldset class="property-form__fieldset">
+        <legend class="property-form__legend">Cardinality</legend>
+        <div class="property-form__range-toggle">
+          <label class="property-form__radio-label">
+            <input
+              type="radio"
+              name="cardinality"
+              value="single"
+              checked={cardinality === "single"}
+              onChange={() => setCardinality("single")}
+            />
+            Single
+          </label>
+          <label class="property-form__radio-label">
+            <input
+              type="radio"
+              name="cardinality"
+              value="multiple"
+              checked={cardinality === "multiple"}
+              onChange={() => setCardinality("multiple")}
+            />
+            Multiple
+          </label>
+        </div>
+      </fieldset>
+
+      <label class="property-form__checkbox-label">
+        <input
+          type="checkbox"
+          checked={required}
+          onChange={(e) => setRequired(e.currentTarget.checked)}
+        />
+        Required
+      </label>
+
+      {!canSubmit && !loading && (
+        <div class="property-form__missing" aria-live="polite">
+          {missingFields.length > 0
+            ? `Still needed: ${missingFields.join(", ")}`
+            : "No changes to save"}
+        </div>
+      )}
+
+      <div class="property-form__actions">
+        <Button variant="secondary" onClick={onCancel}>
+          Cancel
+        </Button>
+        <Button type="submit" disabled={!canSubmit}>
+          {loading ? "Saving..." : isEdit ? "Save Changes" : "Create Property"}
+        </Button>
+      </div>
+    </form>
+  );
+}

--- a/frontend/src/components/workspace/SchemesPane.css
+++ b/frontend/src/components/workspace/SchemesPane.css
@@ -40,6 +40,21 @@
   padding: var(--spacing-sm);
 }
 
+.schemes-pane__nav {
+  margin-bottom: var(--spacing-sm);
+  padding-bottom: var(--spacing-sm);
+  border-bottom: 1px solid var(--color-border);
+}
+
+.schemes-pane__section-label {
+  font-size: var(--font-size-xs);
+  font-weight: 600;
+  color: var(--color-text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  padding: var(--spacing-xs) var(--spacing-md);
+}
+
 .schemes-pane__list {
   display: flex;
   flex-direction: column;

--- a/frontend/src/components/workspace/SchemesPane.tsx
+++ b/frontend/src/components/workspace/SchemesPane.tsx
@@ -6,7 +6,9 @@ import "./SchemesPane.css";
 interface SchemesPaneProps {
   projectId: string;
   currentSchemeId: string | null;
+  showProperties: boolean;
   onSchemeSelect: (schemeId: string) => void;
+  onPropertiesSelect: () => void;
   onNewScheme: () => void;
   onImport: () => void;
 }
@@ -14,7 +16,9 @@ interface SchemesPaneProps {
 export function SchemesPane({
   projectId,
   currentSchemeId,
+  showProperties,
   onSchemeSelect,
+  onPropertiesSelect,
   onNewScheme,
   onImport,
 }: SchemesPaneProps) {
@@ -31,6 +35,17 @@ export function SchemesPane({
       </div>
 
       <div class="schemes-pane__content">
+        <div class="schemes-pane__nav">
+          <button
+            class={`schemes-pane__item ${showProperties ? "schemes-pane__item--selected" : ""}`}
+            onClick={onPropertiesSelect}
+          >
+            Properties
+          </button>
+        </div>
+
+        <div class="schemes-pane__section-label">Schemes</div>
+
         {projectSchemes.length === 0 ? (
           <div class="schemes-pane__empty">No schemes in this project</div>
         ) : (

--- a/frontend/src/pages/SchemeWorkspacePage.css
+++ b/frontend/src/pages/SchemeWorkspacePage.css
@@ -21,6 +21,14 @@
   background: var(--color-bg-secondary);
 }
 
+.scheme-workspace__main--wide {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  overflow: hidden;
+  grid-column: 2 / -1;
+}
+
 .scheme-workspace__placeholder {
   display: flex;
   align-items: center;

--- a/frontend/src/state/properties.ts
+++ b/frontend/src/state/properties.ts
@@ -1,0 +1,9 @@
+import { signal } from "@preact/signals";
+import type { Property, CoreOntologyResponse } from "../types/models";
+
+export const properties = signal<Property[]>([]);
+export const propertiesLoading = signal(false);
+export const propertiesError = signal<string | null>(null);
+
+export const coreOntology = signal<CoreOntologyResponse | null>(null);
+export const coreOntologyLoading = signal(false);

--- a/frontend/src/types/models.ts
+++ b/frontend/src/types/models.ts
@@ -161,6 +161,73 @@ export interface PublishedVersionCreate {
   notes?: string | null;
 }
 
+// ============ Properties ============
+export interface ConceptSchemeBrief {
+  id: string;
+  title: string;
+  uri: string | null;
+}
+
+export interface Property {
+  id: string;
+  project_id: string;
+  identifier: string;
+  label: string;
+  description: string | null;
+  domain_class: string;
+  range_scheme_id: string | null;
+  range_scheme: ConceptSchemeBrief | null;
+  range_datatype: string | null;
+  cardinality: "single" | "multiple";
+  required: boolean;
+  uri: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface PropertyCreate {
+  identifier: string;
+  label: string;
+  description?: string | null;
+  domain_class: string;
+  range_scheme_id?: string | null;
+  range_datatype?: string | null;
+  cardinality: "single" | "multiple";
+  required: boolean;
+}
+
+export interface PropertyUpdate {
+  label?: string;
+  description?: string | null;
+  domain_class?: string;
+  range_scheme_id?: string | null;
+  range_datatype?: string | null;
+  cardinality?: "single" | "multiple";
+  required?: boolean;
+}
+
+// ============ Ontology ============
+export interface OntologyClass {
+  uri: string;
+  label: string;
+  comment: string | null;
+}
+
+export interface OntologyProperty {
+  uri: string;
+  label: string;
+  comment: string | null;
+  domain: string[];
+  range: string[];
+  property_type: "object" | "datatype";
+}
+
+export interface CoreOntologyResponse {
+  classes: OntologyClass[];
+  object_properties: OntologyProperty[];
+  datatype_properties: OntologyProperty[];
+}
+
 // ============ Comments ============
 export interface CommentAuthor {
   id: string;

--- a/frontend/tests/api/properties.test.ts
+++ b/frontend/tests/api/properties.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { propertiesApi, ontologyApi } from "../../src/api/properties";
+
+vi.mock("../../src/api/auth", () => ({
+  getToken: vi.fn(),
+}));
+
+vi.mock("../../src/state/auth", () => ({
+  clearAuth: vi.fn(),
+}));
+
+import { getToken } from "../../src/api/auth";
+
+describe("propertiesApi", () => {
+  const mockFetch = vi.fn();
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    global.fetch = mockFetch;
+    vi.mocked(getToken).mockResolvedValue("test-token");
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    vi.clearAllMocks();
+  });
+
+  it("listForProject calls correct endpoint", async () => {
+    const mockProperties = [{ id: "p1", label: "Test" }];
+    mockFetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve(mockProperties),
+    });
+
+    const result = await propertiesApi.listForProject("proj-1");
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const [url] = mockFetch.mock.calls[0];
+    expect(url).toBe("/api/projects/proj-1/properties");
+    expect(result).toEqual(mockProperties);
+  });
+
+  it("create sends POST with data", async () => {
+    const created = { id: "p1", label: "New Prop" };
+    mockFetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve(created),
+    });
+
+    const data = {
+      identifier: "has-author",
+      label: "Has Author",
+      domain_class: "http://example.org/Finding",
+      range_datatype: "xsd:string",
+      cardinality: "single" as const,
+      required: false,
+    };
+    await propertiesApi.create("proj-1", data);
+
+    const [url, options] = mockFetch.mock.calls[0];
+    expect(url).toBe("/api/projects/proj-1/properties");
+    expect(options.method).toBe("POST");
+    expect(JSON.parse(options.body)).toEqual(data);
+  });
+
+  it("update sends PUT with data", async () => {
+    const updated = { id: "p1", label: "Updated" };
+    mockFetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve(updated),
+    });
+
+    await propertiesApi.update("p1", { label: "Updated" });
+
+    const [url, options] = mockFetch.mock.calls[0];
+    expect(url).toBe("/api/properties/p1");
+    expect(options.method).toBe("PUT");
+  });
+
+  it("delete sends DELETE", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      status: 204,
+    });
+
+    await propertiesApi.delete("p1");
+
+    const [url, options] = mockFetch.mock.calls[0];
+    expect(url).toBe("/api/properties/p1");
+    expect(options.method).toBe("DELETE");
+  });
+});
+
+describe("ontologyApi", () => {
+  const mockFetch = vi.fn();
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    global.fetch = mockFetch;
+    vi.mocked(getToken).mockResolvedValue("test-token");
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    vi.clearAllMocks();
+  });
+
+  it("get calls /ontology endpoint", async () => {
+    const mockOntology = {
+      classes: [{ uri: "http://ex.org/Finding", label: "Finding", comment: null }],
+      object_properties: [],
+      datatype_properties: [],
+    };
+    mockFetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve(mockOntology),
+    });
+
+    const result = await ontologyApi.get();
+
+    const [url] = mockFetch.mock.calls[0];
+    expect(url).toBe("/api/ontology");
+    expect(result).toEqual(mockOntology);
+  });
+});

--- a/frontend/tests/components/properties/PropertiesPane.test.tsx
+++ b/frontend/tests/components/properties/PropertiesPane.test.tsx
@@ -1,0 +1,134 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/preact";
+import { PropertiesPane } from "../../../src/components/properties/PropertiesPane";
+import type { Property, ConceptScheme, OntologyClass } from "../../../src/types/models";
+
+const mockSchemes: ConceptScheme[] = [
+  {
+    id: "scheme-1",
+    project_id: "proj-1",
+    title: "Animals",
+    description: null,
+    uri: "http://example.org/animals",
+    publisher: null,
+    version: null,
+    created_at: "2024-01-01T00:00:00Z",
+    updated_at: "2024-01-01T00:00:00Z",
+  },
+];
+
+const mockOntologyClasses: OntologyClass[] = [
+  { uri: "http://example.org/Finding", label: "Finding", comment: null },
+];
+
+const mockProperties: Property[] = [
+  {
+    id: "prop-1",
+    project_id: "proj-1",
+    identifier: "has-author",
+    label: "Has Author",
+    description: "The author",
+    domain_class: "http://example.org/Finding",
+    range_scheme_id: "scheme-1",
+    range_scheme: { id: "scheme-1", title: "Animals", uri: "http://example.org/animals" },
+    range_datatype: null,
+    cardinality: "single",
+    required: true,
+    uri: "http://example.org/has-author",
+    created_at: "2024-01-01T00:00:00Z",
+    updated_at: "2024-01-01T00:00:00Z",
+  },
+  {
+    id: "prop-2",
+    project_id: "proj-1",
+    identifier: "publication-date",
+    label: "Publication Date",
+    description: null,
+    domain_class: "http://example.org/Finding",
+    range_scheme_id: null,
+    range_scheme: null,
+    range_datatype: "xsd:date",
+    cardinality: "single",
+    required: false,
+    uri: "http://example.org/publication-date",
+    created_at: "2024-01-02T00:00:00Z",
+    updated_at: "2024-01-02T00:00:00Z",
+  },
+];
+
+describe("PropertiesPane", () => {
+  const defaultProps = {
+    projectId: "proj-1",
+    properties: mockProperties,
+    schemes: mockSchemes,
+    ontologyClasses: mockOntologyClasses,
+    onEdit: vi.fn(),
+    onDelete: vi.fn(),
+    onCreate: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it("renders table with property data", () => {
+    render(<PropertiesPane {...defaultProps} />);
+
+    expect(screen.getByText("Has Author")).toBeInTheDocument();
+    expect(screen.getByText("has-author")).toBeInTheDocument();
+    expect(screen.getByText("Publication Date")).toBeInTheDocument();
+    expect(screen.getByText("publication-date")).toBeInTheDocument();
+  });
+
+  it("shows domain class label from ontology", () => {
+    render(<PropertiesPane {...defaultProps} />);
+
+    // Both properties have Finding as domain
+    const findingCells = screen.getAllByText("Finding");
+    expect(findingCells.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("shows scheme title for scheme range", () => {
+    render(<PropertiesPane {...defaultProps} />);
+
+    expect(screen.getByText("Animals")).toBeInTheDocument();
+  });
+
+  it("shows datatype for datatype range", () => {
+    render(<PropertiesPane {...defaultProps} />);
+
+    expect(screen.getByText("xsd:date")).toBeInTheDocument();
+  });
+
+  it("shows empty state when no properties", () => {
+    render(<PropertiesPane {...defaultProps} properties={[]} />);
+
+    expect(screen.getByText(/no properties/i)).toBeInTheDocument();
+  });
+
+  it("calls onCreate when New Property button is clicked", () => {
+    render(<PropertiesPane {...defaultProps} />);
+
+    fireEvent.click(screen.getByText("New Property"));
+
+    expect(defaultProps.onCreate).toHaveBeenCalled();
+  });
+
+  it("calls onEdit with correct property when edit is clicked", () => {
+    render(<PropertiesPane {...defaultProps} />);
+
+    const editButtons = screen.getAllByText("Edit");
+    fireEvent.click(editButtons[0]);
+
+    expect(defaultProps.onEdit).toHaveBeenCalledWith(mockProperties[0]);
+  });
+
+  it("calls onDelete with correct property when delete is clicked", () => {
+    render(<PropertiesPane {...defaultProps} />);
+
+    const deleteButtons = screen.getAllByText("Delete");
+    fireEvent.click(deleteButtons[0]);
+
+    expect(defaultProps.onDelete).toHaveBeenCalledWith(mockProperties[0]);
+  });
+});

--- a/frontend/tests/components/properties/PropertyForm.test.tsx
+++ b/frontend/tests/components/properties/PropertyForm.test.tsx
@@ -1,0 +1,246 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/preact";
+import { PropertyForm, labelToIdentifier } from "../../../src/components/properties/PropertyForm";
+import type { ConceptScheme, OntologyClass, Property } from "../../../src/types/models";
+
+vi.mock("../../../src/api/properties", () => ({
+  propertiesApi: {
+    create: vi.fn(),
+    update: vi.fn(),
+  },
+}));
+
+import { propertiesApi } from "../../../src/api/properties";
+
+const mockSchemes: ConceptScheme[] = [
+  {
+    id: "scheme-1",
+    project_id: "proj-1",
+    title: "Animals",
+    description: null,
+    uri: "http://example.org/animals",
+    publisher: null,
+    version: null,
+    created_at: "2024-01-01T00:00:00Z",
+    updated_at: "2024-01-01T00:00:00Z",
+  },
+];
+
+const mockOntologyClasses: OntologyClass[] = [
+  { uri: "http://example.org/Finding", label: "Finding", comment: null },
+  { uri: "http://example.org/Intervention", label: "Intervention", comment: null },
+];
+
+const mockProperty: Property = {
+  id: "prop-1",
+  project_id: "proj-1",
+  identifier: "has-author",
+  label: "Has Author",
+  description: "The author of a finding",
+  domain_class: "http://example.org/Finding",
+  range_scheme_id: "scheme-1",
+  range_scheme: { id: "scheme-1", title: "Animals", uri: "http://example.org/animals" },
+  range_datatype: null,
+  cardinality: "single",
+  required: false,
+  uri: "http://example.org/has-author",
+  created_at: "2024-01-01T00:00:00Z",
+  updated_at: "2024-01-01T00:00:00Z",
+};
+
+describe("labelToIdentifier", () => {
+  it("converts label to lowercase kebab-case", () => {
+    expect(labelToIdentifier("Has Author")).toBe("has-author");
+  });
+
+  it("prefixes with prop- when starts with digit", () => {
+    expect(labelToIdentifier("3 months")).toBe("prop-3-months");
+  });
+
+  it("strips punctuation", () => {
+    expect(labelToIdentifier("Cost ($)")).toBe("cost");
+  });
+
+  it("returns empty string for empty input", () => {
+    expect(labelToIdentifier("")).toBe("");
+  });
+
+  it("strips non-ASCII characters", () => {
+    expect(labelToIdentifier("Áccent")).toBe("ccent");
+  });
+
+  it("collapses multiple hyphens", () => {
+    expect(labelToIdentifier("hello   world")).toBe("hello-world");
+  });
+
+  it("trims leading and trailing hyphens", () => {
+    expect(labelToIdentifier("  hello  ")).toBe("hello");
+  });
+});
+
+describe("PropertyForm", () => {
+  const defaultProps = {
+    projectId: "proj-1",
+    schemes: mockSchemes,
+    ontologyClasses: mockOntologyClasses,
+    onSuccess: vi.fn(),
+    onCancel: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it("shows 'Create Property' button in create mode", () => {
+    render(<PropertyForm {...defaultProps} />);
+    expect(screen.getByText("Create Property")).toBeInTheDocument();
+  });
+
+  it("shows 'Save Changes' button in edit mode", () => {
+    render(<PropertyForm {...defaultProps} property={mockProperty} />);
+    expect(screen.getByText("Save Changes")).toBeInTheDocument();
+  });
+
+  it("auto-generates identifier from label", () => {
+    render(<PropertyForm {...defaultProps} />);
+
+    const labelInput = screen.getByLabelText(/Label/);
+    fireEvent.input(labelInput, { target: { value: "Has Author" } });
+
+    const identifierInput = screen.getByLabelText(/Identifier/) as HTMLInputElement;
+    expect(identifierInput.value).toBe("has-author");
+  });
+
+  it("stops auto-generating after manual identifier edit", () => {
+    render(<PropertyForm {...defaultProps} />);
+
+    const identifierInput = screen.getByLabelText(/Identifier/);
+    fireEvent.input(identifierInput, { target: { value: "custom-id" } });
+
+    const labelInput = screen.getByLabelText(/Label/);
+    fireEvent.input(labelInput, { target: { value: "Has Author" } });
+
+    expect((identifierInput as HTMLInputElement).value).toBe("custom-id");
+  });
+
+  it("makes identifier read-only in edit mode", () => {
+    render(<PropertyForm {...defaultProps} property={mockProperty} />);
+
+    const identifierInput = screen.getByLabelText(/Identifier/);
+    expect(identifierInput).toHaveAttribute("readonly");
+  });
+
+  it("shows range toggle with Concept Scheme and Datatype options", () => {
+    render(<PropertyForm {...defaultProps} />);
+
+    expect(screen.getByLabelText("Concept Scheme")).toBeInTheDocument();
+    expect(screen.getByLabelText("Datatype")).toBeInTheDocument();
+  });
+
+  it("disables Concept Scheme option when no schemes exist", () => {
+    render(<PropertyForm {...defaultProps} schemes={[]} />);
+
+    const schemeRadio = screen.getByRole("radio", { name: /concept scheme/i });
+    expect(schemeRadio).toBeDisabled();
+  });
+
+  it("shows scheme select when Concept Scheme is selected", () => {
+    render(<PropertyForm {...defaultProps} />);
+
+    const schemeRadio = screen.getByLabelText("Concept Scheme");
+    fireEvent.click(schemeRadio);
+
+    expect(screen.getByText("Animals")).toBeInTheDocument();
+  });
+
+  it("shows datatype select when Datatype is selected", () => {
+    render(<PropertyForm {...defaultProps} />);
+
+    const datatypeRadio = screen.getByLabelText("Datatype");
+    fireEvent.click(datatypeRadio);
+
+    expect(screen.getByText("xsd:string")).toBeInTheDocument();
+  });
+
+  it("shows inline error for invalid identifier", () => {
+    render(<PropertyForm {...defaultProps} />);
+
+    const identifierInput = screen.getByLabelText(/Identifier/);
+    fireEvent.input(identifierInput, { target: { value: "123-bad" } });
+
+    expect(screen.getByText(/must start with a letter/i)).toBeInTheDocument();
+  });
+
+  it("populates form fields from existing property", () => {
+    render(<PropertyForm {...defaultProps} property={mockProperty} />);
+
+    expect(screen.getByDisplayValue("Has Author")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("has-author")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("The author of a finding")).toBeInTheDocument();
+  });
+
+  it("calls propertiesApi.create on submit in create mode", async () => {
+    vi.mocked(propertiesApi.create).mockResolvedValue(mockProperty);
+
+    render(<PropertyForm {...defaultProps} />);
+
+    fireEvent.input(screen.getByLabelText(/Label/), { target: { value: "Has Author" } });
+
+    // Select domain class
+    const domainSelect = screen.getByLabelText(/Applies to/);
+    fireEvent.change(domainSelect, { target: { value: "http://example.org/Finding" } });
+
+    // Select range: datatype
+    fireEvent.click(screen.getByLabelText("Datatype"));
+    const datatypeSelect = screen.getByLabelText(/Datatype select/);
+    fireEvent.change(datatypeSelect, { target: { value: "xsd:string" } });
+
+    fireEvent.submit(screen.getByRole("form"));
+
+    // Wait for async submit
+    await waitFor(() => {
+      expect(propertiesApi.create).toHaveBeenCalledWith("proj-1", expect.objectContaining({
+        label: "Has Author",
+        identifier: "has-author",
+        domain_class: "http://example.org/Finding",
+        range_datatype: "xsd:string",
+      }));
+    });
+  });
+
+  it("calls propertiesApi.update on submit in edit mode", async () => {
+    vi.mocked(propertiesApi.update).mockResolvedValue(mockProperty);
+
+    render(<PropertyForm {...defaultProps} property={mockProperty} />);
+
+    fireEvent.input(screen.getByLabelText(/Label/), { target: { value: "Updated Label" } });
+    fireEvent.submit(screen.getByRole("form"));
+
+    await waitFor(() => {
+      expect(propertiesApi.update).toHaveBeenCalledWith("prop-1", expect.objectContaining({
+        label: "Updated Label",
+      }));
+    });
+  });
+
+  it("displays 409 error as duplicate identifier message", async () => {
+    const { ApiError } = await import("../../../src/api/client");
+    vi.mocked(propertiesApi.create).mockRejectedValue(
+      new ApiError(409, "Property with this identifier already exists")
+    );
+
+    render(<PropertyForm {...defaultProps} />);
+
+    fireEvent.input(screen.getByLabelText(/Label/), { target: { value: "Test" } });
+    const domainSelect = screen.getByLabelText(/Applies to/);
+    fireEvent.change(domainSelect, { target: { value: "http://example.org/Finding" } });
+    fireEvent.click(screen.getByLabelText("Datatype"));
+    fireEvent.change(screen.getByLabelText(/Datatype select/), { target: { value: "xsd:string" } });
+
+    fireEvent.submit(screen.getByRole("form"));
+
+    await waitFor(() => {
+      expect(screen.getByText(/already exists/i)).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/tests/components/workspace/SchemesPane.test.tsx
+++ b/frontend/tests/components/workspace/SchemesPane.test.tsx
@@ -41,8 +41,19 @@ const mockSchemes: ConceptScheme[] = [
 
 describe("SchemesPane", () => {
   const mockOnSchemeSelect = vi.fn();
+  const mockOnPropertiesSelect = vi.fn();
   const mockOnNewScheme = vi.fn();
   const mockOnImport = vi.fn();
+
+  const defaultProps = {
+    projectId: "proj-1",
+    currentSchemeId: null as string | null,
+    showProperties: false,
+    onSchemeSelect: mockOnSchemeSelect,
+    onPropertiesSelect: mockOnPropertiesSelect,
+    onNewScheme: mockOnNewScheme,
+    onImport: mockOnImport,
+  };
 
   beforeEach(() => {
     vi.resetAllMocks();
@@ -51,74 +62,34 @@ describe("SchemesPane", () => {
   });
 
   it("renders current project name as heading", () => {
-    render(
-      <SchemesPane
-        projectId="proj-1"
-        currentSchemeId={null}
-        onSchemeSelect={mockOnSchemeSelect}
-        onNewScheme={mockOnNewScheme}
-        onImport={mockOnImport}
-      />
-    );
+    render(<SchemesPane {...defaultProps} />);
 
     expect(screen.getByText("Project One")).toBeInTheDocument();
   });
 
   it("renders back link to projects", () => {
-    render(
-      <SchemesPane
-        projectId="proj-1"
-        currentSchemeId={null}
-        onSchemeSelect={mockOnSchemeSelect}
-        onNewScheme={mockOnNewScheme}
-        onImport={mockOnImport}
-      />
-    );
+    render(<SchemesPane {...defaultProps} />);
 
     const backLink = screen.getByRole("link", { name: /projects/i });
     expect(backLink).toHaveAttribute("href", "/projects");
   });
 
   it("lists schemes for the current project", () => {
-    render(
-      <SchemesPane
-        projectId="proj-1"
-        currentSchemeId={null}
-        onSchemeSelect={mockOnSchemeSelect}
-        onNewScheme={mockOnNewScheme}
-        onImport={mockOnImport}
-      />
-    );
+    render(<SchemesPane {...defaultProps} />);
 
     expect(screen.getByText("Animals")).toBeInTheDocument();
     expect(screen.getByText("Plants")).toBeInTheDocument();
   });
 
   it("highlights the current scheme", () => {
-    render(
-      <SchemesPane
-        projectId="proj-1"
-        currentSchemeId="scheme-1"
-        onSchemeSelect={mockOnSchemeSelect}
-        onNewScheme={mockOnNewScheme}
-        onImport={mockOnImport}
-      />
-    );
+    render(<SchemesPane {...defaultProps} currentSchemeId="scheme-1" />);
 
     const schemeList = screen.getByRole("button", { name: "Animals" });
     expect(schemeList).toHaveClass("schemes-pane__item--selected");
   });
 
   it("calls onSchemeSelect when scheme is clicked", () => {
-    render(
-      <SchemesPane
-        projectId="proj-1"
-        currentSchemeId={null}
-        onSchemeSelect={mockOnSchemeSelect}
-        onNewScheme={mockOnNewScheme}
-        onImport={mockOnImport}
-      />
-    );
+    render(<SchemesPane {...defaultProps} />);
 
     fireEvent.click(screen.getByText("Animals"));
 
@@ -128,29 +99,13 @@ describe("SchemesPane", () => {
   it("shows empty state when project has no schemes", () => {
     schemes.value = [];
 
-    render(
-      <SchemesPane
-        projectId="proj-1"
-        currentSchemeId={null}
-        onSchemeSelect={mockOnSchemeSelect}
-        onNewScheme={mockOnNewScheme}
-        onImport={mockOnImport}
-      />
-    );
+    render(<SchemesPane {...defaultProps} />);
 
     expect(screen.getByText(/no schemes/i)).toBeInTheDocument();
   });
 
   it("calls onNewScheme when New Scheme button is clicked", () => {
-    render(
-      <SchemesPane
-        projectId="proj-1"
-        currentSchemeId={null}
-        onSchemeSelect={mockOnSchemeSelect}
-        onNewScheme={mockOnNewScheme}
-        onImport={mockOnImport}
-      />
-    );
+    render(<SchemesPane {...defaultProps} />);
 
     fireEvent.click(screen.getByText("+ New Scheme"));
 
@@ -158,18 +113,40 @@ describe("SchemesPane", () => {
   });
 
   it("calls onImport when Import button is clicked", () => {
-    render(
-      <SchemesPane
-        projectId="proj-1"
-        currentSchemeId={null}
-        onSchemeSelect={mockOnSchemeSelect}
-        onNewScheme={mockOnNewScheme}
-        onImport={mockOnImport}
-      />
-    );
+    render(<SchemesPane {...defaultProps} />);
 
     fireEvent.click(screen.getByText("Import"));
 
     expect(mockOnImport).toHaveBeenCalled();
+  });
+
+  it("renders Properties nav item", () => {
+    render(<SchemesPane {...defaultProps} />);
+
+    expect(screen.getByRole("button", { name: "Properties" })).toBeInTheDocument();
+  });
+
+  it("calls onPropertiesSelect when Properties is clicked", () => {
+    render(<SchemesPane {...defaultProps} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Properties" }));
+
+    expect(mockOnPropertiesSelect).toHaveBeenCalled();
+  });
+
+  it("highlights Properties when showProperties is true", () => {
+    render(<SchemesPane {...defaultProps} showProperties={true} />);
+
+    const propertiesBtn = screen.getByRole("button", { name: "Properties" });
+    expect(propertiesBtn).toHaveClass("schemes-pane__item--selected");
+  });
+
+  it("does not highlight Properties when a scheme is selected", () => {
+    render(
+      <SchemesPane {...defaultProps} currentSchemeId="scheme-1" showProperties={false} />
+    );
+
+    const propertiesBtn = screen.getByRole("button", { name: "Properties" });
+    expect(propertiesBtn).not.toHaveClass("schemes-pane__item--selected");
   });
 });


### PR DESCRIPTION
## Summary

- Properties are managed from the project route (`/projects/:projectId`), using the full main pane width when no scheme is selected
- Table view lists properties with label, identifier, domain class, range, cardinality, and required status
- Create/edit modal form with auto-generated identifier from label, client-side validation, and range toggle (concept scheme vs XSD datatype)
- "Properties" nav item in the sidebar with active state highlight
- Keyboard and screen reader accessible: Tab navigation, Escape to close modals, live validation hints, labeled action buttons

## Details

Built on top of the backend property CRUD from PR #47. New files follow existing patterns (`api/schemes.ts`, `state/schemes.ts`, `ConceptForm.tsx`).

**New components:**
- `PropertiesPane` — table with edit/delete actions, loading/error states, empty state
- `PropertyForm` — modal form with `labelToIdentifier()` slug generation, identifier regex validation (read-only on edit), smart range default (falls back to datatype when no schemes exist), "still needed" hint listing missing required fields

**Modified shared components:**
- `Button` — accepts `aria-label` passthrough
- `ConfirmDialog` — warning icon on danger variant, high-contrast message text, uses `--color-danger` theme var
- `SchemesPane` — "Properties" nav item with `showProperties`/`onPropertiesSelect` props

**Terminology:** user-facing text uses "vocabulary" not "ontology".

## Test plan

- [x] `npm test` — 297 tests passing (34 new)
- [x] `npm run typecheck` — clean
- [ ] Create property with scheme range — appears in table
- [ ] Create property with datatype range — appears in table
- [ ] Edit property — identifier read-only, changes saved
- [ ] Delete with confirmation dialog
- [ ] Auto-generated identifier updates while typing label
- [ ] Duplicate identifier shows error
- [ ] Domain class dropdown populated from ontology
- [ ] "Concept Scheme" range option disabled when project has no schemes
- [ ] Tab through form — all fields reachable, Escape closes modal