### PR TITLE
Disable deploy workflow on push to main

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,9 +11,6 @@ on:
         type: string
         description: environment to deploy to
         required: true
-  push:
-    branches:
-      - main
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
This is consistently failing and we don't want it to trigger on merge for the time being. 