### PR TITLE
Fix published-format example files to match schema

### DIFF
--- a/docs/published-format/example/01965a00-0000-7000-8000-000000000000/1.0/vocabulary.json
+++ b/docs/published-format/example/01965a00-0000-7000-8000-000000000000/1.0/vocabulary.json
@@ -5,6 +5,7 @@
   "published_at": "2026-02-01T09:00:00Z",
   "publisher": "Jane Smith",
   "pre_release": false,
+  "previous_version_id": null,
   "project": {
     "id": "01965a00-0000-7000-8000-000000000000",
     "name": "Demo Taxonomy",
@@ -133,6 +134,7 @@
       "range_scheme_id": "01965a00-0000-7000-8000-000000000001",
       "range_scheme_uri": "http://example.org/demo/colors",
       "range_datatype": null,
+      "range_class": null,
       "cardinality": "single",
       "required": false
     }

--- a/docs/published-format/example/01965a00-0000-7000-8000-000000000000/2.0/vocabulary.json
+++ b/docs/published-format/example/01965a00-0000-7000-8000-000000000000/2.0/vocabulary.json
@@ -5,6 +5,7 @@
   "published_at": "2026-03-01T09:00:00Z",
   "publisher": "Jane Smith",
   "pre_release": false,
+  "previous_version_id": "01965a00-0000-7000-8000-c00000000001",
   "project": {
     "id": "01965a00-0000-7000-8000-000000000000",
     "name": "Demo Taxonomy",
@@ -175,6 +176,7 @@
       "range_scheme_id": "01965a00-0000-7000-8000-000000000001",
       "range_scheme_uri": "http://example.org/demo/colors",
       "range_datatype": null,
+      "range_class": null,
       "cardinality": "single",
       "required": false
     }

--- a/docs/published-format/example/01965a00-0000-7000-8000-000000000000/index.json
+++ b/docs/published-format/example/01965a00-0000-7000-8000-000000000000/index.json
@@ -14,6 +14,7 @@
       "published_at": "2026-03-01T09:00:00Z",
       "publisher": "Jane Smith",
       "pre_release": false,
+      "previous_version_id": "01965a00-0000-7000-8000-c00000000001",
       "notes": "Organised into warm and cool categories, added turquoise and orange.",
       "content_summary": {
         "schemes": 1,
@@ -28,6 +29,7 @@
       "published_at": "2026-02-01T09:00:00Z",
       "publisher": "Jane Smith",
       "pre_release": false,
+      "previous_version_id": null,
       "notes": null,
       "content_summary": {
         "schemes": 1,


### PR DESCRIPTION
## Summary

Adds missing fields to the published-format example JSON files so they
conform to the vocabulary schema.

- Add `previous_version_id` to both vocabulary files and the project index
  (null for v1.0, references v1.0's ID for v2.0)
- Add `range_class: null` to properties that use `range_scheme_id`

## Context

The schema was updated in two commits that didn't update the examples:
- `c3e9db6` added `previous_version_id` to the schema
- `c756e29` added `range_class` to the schema

The `range_class` feature was built across multiple contributors (Jaybe, Jack,
Adam) but the example files were missed by all of us.

## Test plan

- [x] All three example JSON files are valid JSON
- [ ] Examples validate against `vocabulary.schema.json` and `project-index.schema.json`