### PR TITLE
Update evrepo-core: Condition name/description properties, widen CI domain to ObservedResult

### DIFF
--- a/vocab/esea/esea-vocab.ttl
+++ b/vocab/esea/esea-vocab.ttl
@@ -1173,7 +1173,8 @@ esea:implementationDescription a owl:ObjectProperty ;
     rdfs:label "implementation description"@en ;
     rdfs:comment "Type of implementation activity or modality. Multiple values may be coded."@en ;
     rdfs:domain evrepo:Intervention ;
-    rdfs:range esea:ImplementationDescriptionCodingAnnotation .
+    rdfs:range esea:ImplementationDescriptionCodingAnnotation ;
+    rdfs:subPropertyOf evrepo:description .
 
 # --- Concept Scheme ---
 
@@ -1653,7 +1654,8 @@ esea:implementationName a owl:ObjectProperty ;
     rdfs:label "implementation name"@en ;
     rdfs:comment "Name or title of the intervention. Open text field."@en ;
     rdfs:domain evrepo:Intervention ;
-    rdfs:range evrepo:StringCodingAnnotation .
+    rdfs:range evrepo:StringCodingAnnotation ;
+    rdfs:subPropertyOf evrepo:name .
 
 
 # #############################################################################

--- a/vocab/evrepo-core/evrepo-core.ttl
+++ b/vocab/evrepo-core/evrepo-core.ttl
@@ -55,6 +55,18 @@ evrepo:Condition a owl:Class ;
     rdfs:label "Condition"@en ;
     rdfs:comment "A state or context in which measurements were taken — the circumstances under which observations were made."@en .
 
+evrepo:name a owl:DatatypeProperty ;
+    rdfs:label "name"@en ;
+    rdfs:domain evrepo:Condition ;
+    rdfs:range xsd:string ;
+    rdfs:comment "Short name or title for this condition (e.g. intervention programme name, control label)."@en .
+
+evrepo:description a owl:DatatypeProperty ;
+    rdfs:label "description"@en ;
+    rdfs:domain evrepo:Condition ;
+    rdfs:range xsd:string ;
+    rdfs:comment "Free-text description of this condition."@en .
+
 evrepo:Intervention a owl:Class ;
     rdfs:subClassOf evrepo:Condition ;
     rdfs:label "Intervention"@en ;
@@ -322,13 +334,15 @@ evrepo:confidenceLevel a owl:DatatypeProperty ;
 
 evrepo:confidenceIntervalLower a owl:DatatypeProperty ;
     rdfs:label "confidence interval lower bound"@en ;
-    rdfs:domain evrepo:EffectEstimate ;
-    rdfs:range xsd:decimal .
+    rdfs:domain [ a owl:Class ; owl:unionOf ( evrepo:EffectEstimate evrepo:ObservedResult ) ] ;
+    rdfs:range xsd:decimal ;
+    rdfs:comment "Applies to EffectEstimate (effect size CI) and ObservedResult (group mean CI)."@en .
 
 evrepo:confidenceIntervalUpper a owl:DatatypeProperty ;
     rdfs:label "confidence interval upper bound"@en ;
-    rdfs:domain evrepo:EffectEstimate ;
-    rdfs:range xsd:decimal .
+    rdfs:domain [ a owl:Class ; owl:unionOf ( evrepo:EffectEstimate evrepo:ObservedResult ) ] ;
+    rdfs:range xsd:decimal ;
+    rdfs:comment "Applies to EffectEstimate (effect size CI) and ObservedResult (group mean CI)."@en .
 
 evrepo:baselineAdjusted a owl:DatatypeProperty ;
     rdfs:label "baseline adjusted"@en ;


### PR DESCRIPTION
Vocab-only changes identified during EEF → ESEA mapping work (destiny-evidence/taxonomy-builder#148).

## Changes

**`vocab/evrepo-core/evrepo-core.ttl`**
- Add `evrepo:name` and `evrepo:description` as datatype properties on `evrepo:Condition` — needed so interventions and controls can carry a short name and free-text description
- Widen `rdfs:domain` of `evrepo:confidenceIntervalLower` and `evrepo:confidenceIntervalUpper` from `EffectEstimate` only to `union(EffectEstimate, ObservedResult)` — CI bounds apply to group means as well as effect sizes

**`vocab/esea/esea-vocab.ttl`**
- Mark `esea:implementationDescription` as `rdfs:subPropertyOf evrepo:description`
- Mark `esea:implementationName` as `rdfs:subPropertyOf evrepo:name`

No backend changes. These updates will flow into the builder once the TTL import pipeline (#109, destiny-evidence/destiny-repository#110) is complete.