### PR TITLE
Auto-allocate identifiers for imported concepts with None URI fragments (#138)

### DIFF
--- a/backend/src/taxonomy_builder/services/skos_import_service.py
+++ b/backend/src/taxonomy_builder/services/skos_import_service.py
@@ -391,10 +391,11 @@ class SKOSImportService:
         # Skipped schemes (already existed) are excluded — their identifiers
         # were reconciled during the original import.
         imported_identifiers = [
-            get_identifier_from_uri(concept_uri)
+            ident
             for scheme_uri, concepts in analysis["concepts_by_scheme"].items()
             if str(scheme_uri) not in existing.scheme_uri_to_id
             for concept_uri in concepts
+            if (ident := get_identifier_from_uri(concept_uri)) != "None"
         ]
         await self._project_service.reconcile_identifier_counter(
             project_id, imported_identifiers
@@ -624,6 +625,13 @@ class SKOSImportService:
         for concept_uri in concept_uris:
             pref_label, _ = get_concept_pref_label(g, concept_uri)
             identifier = get_identifier_from_uri(concept_uri)
+
+            # Treat "None" as a missing identifier (legacy data exported before
+            # identifiers were required) and auto-allocate a real one.
+            if identifier == "None":
+                identifier = await self._project_service.allocate_identifier(
+                    project_id
+                )
 
             definition = None
             def_value = g.value(concept_uri, SKOS.definition)

--- a/backend/tests/test_services/test_skos_import_service.py
+++ b/backend/tests/test_services/test_skos_import_service.py
@@ -1454,3 +1454,38 @@ async def test_reimport_skipped_scheme_does_not_advance_counter(
     )
     await db_session.refresh(project_with_prefix)
     assert project_with_prefix.identifier_counter == 3
+
+
+# --- Legacy "None" identifier handling ---
+
+NONE_IDENTIFIER_TTL = b"""
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+
+<http://example.org/scheme/LegacyScheme> a skos:ConceptScheme ;
+    rdfs:label "Legacy Scheme" .
+
+<http://example.org/scheme/LegacyScheme/None> a skos:Concept ;
+    skos:inScheme <http://example.org/scheme/LegacyScheme> ;
+    skos:prefLabel "Legacy Concept A" .
+
+<http://example.org/other/None> a skos:Concept ;
+    skos:inScheme <http://example.org/scheme/LegacyScheme> ;
+    skos:prefLabel "Legacy Concept B" .
+"""
+
+
+@pytest.mark.asyncio
+async def test_import_none_identifiers_auto_allocates(
+    db_session: AsyncSession, project: Project, import_service: SKOSImportService,
+):
+    """Concepts with 'None' URI fragments get auto-allocated identifiers."""
+    result = await import_service.execute(project.id, NONE_IDENTIFIER_TTL, "test.ttl")
+    assert result.total_concepts_created == 2
+
+    concepts = (await db_session.execute(select(Concept))).scalars().all()
+    identifiers = sorted(c.identifier for c in concepts)
+    assert identifiers == ["TST000001", "TST000002"]
+
+    await db_session.refresh(project)
+    assert project.identifier_counter == 2


### PR DESCRIPTION
## Summary

- SKOS import treats `None` URI fragments as missing identifiers and auto-allocates via the project's prefix and counter
- Legacy exports from before identifiers were required produce URIs like `scheme/None` — this handles re-importing that data cleanly
- Filters `None` entries from the reconcile identifier list

## Context

The bulk of #138 frontend UX work (prefix field, auto-gen hint, read-only identifiers, prefix_locked) landed in #163. This PR adds the remaining piece: handling legacy data with missing identifiers on import.

## Test plan

- `test_import_none_identifiers_auto_allocates` — imports TTL with `None` URI fragments, verifies auto-allocation to `TST000001`/`TST000002` and counter update

Closes #138.