### PR TITLE
Emit type-scoped prefix redefinitions for scheme-scoped concept URIs

### DIFF
--- a/backend/src/taxonomy_builder/services/context_generation_service.py
+++ b/backend/src/taxonomy_builder/services/context_generation_service.py
@@ -2,7 +2,8 @@
 
 import logging
 
-from taxonomy_builder.schemas.snapshot import SnapshotVocabulary
+from taxonomy_builder.models.class_restriction import RestrictionType
+from taxonomy_builder.schemas.snapshot import SnapshotClass, SnapshotVocabulary
 
 logger = logging.getLogger(__name__)
 
@@ -42,6 +43,17 @@ class ContextGenerationService:
             if prefix:
                 context[prefix] = namespace
 
+        # Build concept_type_uri → scheme_uri mapping for type-scoped contexts.
+        # When an OWL class has an allValuesFrom restriction whose value matches
+        # a concept type in a scheme, we emit a type-scoped prefix redefinition
+        # so that compact concept codes (e.g. esea:C00074) expand to scheme-
+        # scoped URIs (e.g. esea:EducationThemeScheme/C00074).
+        concept_type_to_scheme_uri: dict[str, str] = {}
+        for scheme in snapshot.concept_schemes:
+            for concept in scheme.concepts:
+                for type_uri in concept.concept_type_uris:
+                    concept_type_to_scheme_uri.setdefault(type_uri, scheme.uri)
+
         # 3. Class term mappings
         # Reserve prefix names so class/property local names can't overwrite them.
         used_terms: dict[str, str] = {prefix: prefix for prefix in prefixes}
@@ -51,6 +63,19 @@ class ContextGenerationService:
             if not local_name:
                 continue
             compact = self._compact_uri(snapshot_class.uri, namespace_to_prefix)
+
+            # Check for allValuesFrom restriction → scheme-scoped prefix
+            term_value: str | dict = compact
+            scheme_uri = self._find_linked_scheme(snapshot_class, concept_type_to_scheme_uri)
+            if scheme_uri:
+                scheme_base = scheme_uri.rstrip("/") + "/"
+                scope_prefix = self._find_prefix_for_uri(scheme_base, namespace_to_prefix)
+                if scope_prefix:
+                    term_value = {
+                        "@id": compact,
+                        "@context": {scope_prefix: scheme_base},
+                    }
+
             if local_name in used_terms:
                 # Collision with existing term or prefix — use full URI as key
                 logger.warning(
@@ -59,10 +84,10 @@ class ContextGenerationService:
                     snapshot_class.uri,
                     local_name,
                 )
-                context[snapshot_class.uri] = compact
+                context[snapshot_class.uri] = term_value
             else:
                 used_terms[local_name] = snapshot_class.uri
-                context[local_name] = compact
+                context[local_name] = term_value
 
         # 4. Property term mappings
         for prop in snapshot.properties:
@@ -139,3 +164,28 @@ class ContextGenerationService:
             if uri.startswith(namespace):
                 return f"{prefix}:{uri[len(namespace) :]}"
         return uri
+
+    @staticmethod
+    def _find_linked_scheme(
+        snapshot_class: SnapshotClass,
+        concept_type_to_scheme_uri: dict[str, str],
+    ) -> str | None:
+        """Find a scheme URI linked via an allValuesFrom restriction.
+
+        If the class restricts a property to allValuesFrom a concept type
+        that appears in a scheme's concepts, return that scheme's URI.
+        """
+        for restriction in snapshot_class.restrictions:
+            if restriction.restriction_type == RestrictionType.ALL_VALUES_FROM:
+                scheme_uri = concept_type_to_scheme_uri.get(restriction.value_uri)
+                if scheme_uri:
+                    return scheme_uri
+        return None
+
+    @staticmethod
+    def _find_prefix_for_uri(uri: str, namespace_to_prefix: dict[str, str]) -> str | None:
+        """Find the prefix whose namespace contains the given URI."""
+        for namespace, prefix in namespace_to_prefix.items():
+            if uri.startswith(namespace) and prefix:
+                return prefix
+        return None

--- a/backend/tests/test_services/test_context_generation.py
+++ b/backend/tests/test_services/test_context_generation.py
@@ -26,10 +26,30 @@ DEFAULT_PREFIXES = {
 }
 
 
+DEFAULT_SCHEME = {
+    "id": str(SCHEME_ID),
+    "title": "Education Level",
+    "uri": f"{PROJECT_NS}educationLevel",
+    "concepts": [
+        {
+            "id": "01965a00-0000-7000-8000-000000000099",
+            "pref_label": "Primary",
+            "identifier": "C00001",
+            "uri": f"{PROJECT_NS}C00001",
+            "broader_ids": [],
+            "related_ids": [],
+            "alt_labels": [],
+            "concept_type_uris": [],
+        }
+    ],
+}
+
+
 def _make_snapshot(
     *,
     classes=None,
     properties=None,
+    concept_schemes=None,
     namespace_prefixes=None,
     namespace=PROJECT_NS,
 ):
@@ -42,25 +62,7 @@ def _make_snapshot(
             "namespace": namespace,
             "namespace_prefixes": namespace_prefixes or DEFAULT_PREFIXES,
         },
-        "concept_schemes": [
-            {
-                "id": str(SCHEME_ID),
-                "title": "Education Level",
-                "uri": f"{PROJECT_NS}educationLevel",
-                "concepts": [
-                    {
-                        "id": "01965a00-0000-7000-8000-000000000099",
-                        "pref_label": "Primary",
-                        "identifier": "C00001",
-                        "uri": f"{PROJECT_NS}C00001",
-                        "broader_ids": [],
-                        "related_ids": [],
-                        "alt_labels": [],
-                        "concept_type_uris": [],
-                    }
-                ],
-            }
-        ],
+        "concept_schemes": concept_schemes if concept_schemes is not None else [DEFAULT_SCHEME],
         "classes": classes or [],
         "properties": properties or [],
     }
@@ -486,3 +488,144 @@ class TestRdfPropertyWithDatatype:
         ctx = ContextGenerationService().generate(snapshot)["@context"]
         assert "dataSource" in ctx, "in-namespace rdf:Property with datatype should not be omitted"
         assert ctx["dataSource"] == {"@type": "xsd:string"}
+
+
+THEME_SCHEME_ID = UUID("01965a00-0000-7000-8000-000000000002")
+
+
+def _theme_scheme(*, concept_type_uris=None):
+    """Build an EducationThemeScheme with a concept that has concept_type_uris."""
+    return {
+        "id": str(THEME_SCHEME_ID),
+        "title": "Education Theme",
+        "uri": f"{PROJECT_NS}EducationThemeScheme",
+        "concepts": [
+            {
+                "id": "01965a00-0000-7000-8000-000000000098",
+                "pref_label": "Literacy and Reading Interventions",
+                "identifier": "C00074",
+                "uri": f"{PROJECT_NS}EducationThemeScheme/C00074",
+                "broader_ids": [],
+                "related_ids": [],
+                "alt_labels": [],
+                "concept_type_uris": concept_type_uris or [f"{PROJECT_NS}EducationThemeConcept"],
+            }
+        ],
+    }
+
+
+def _annotation_class(*, identifier="EducationThemeCodingAnnotation", value_uri=None):
+    """Build a CodingAnnotation class with an allValuesFrom restriction."""
+    return {
+        "id": str(CLASS_ID),
+        "identifier": identifier,
+        "label": identifier.replace("CodingAnnotation", " Coding Annotation"),
+        "uri": f"{PROJECT_NS}{identifier}",
+        "restrictions": [
+            {
+                "on_property_uri": f"{EXTERNAL_NS}codedValue",
+                "restriction_type": "allValuesFrom",
+                "value_uri": value_uri or f"{PROJECT_NS}EducationThemeConcept",
+            }
+        ],
+    }
+
+
+class TestTypeScopedPrefixRedefinition:
+    """Classes with allValuesFrom restrictions linking to a concept scheme
+    should get type-scoped prefix redefinitions in the context.
+
+    This enables pyld to expand esea:C00074 → esea:EducationThemeScheme/C00074
+    when the codedValue appears inside a typed annotation node.
+    """
+
+    def test_annotation_class_gets_scoped_prefix(self):
+        snapshot = _make_snapshot(
+            concept_schemes=[_theme_scheme()],
+            classes=[_annotation_class()],
+        )
+        ctx = ContextGenerationService().generate(snapshot)["@context"]
+        assert ctx["EducationThemeCodingAnnotation"] == {
+            "@id": "esea:EducationThemeCodingAnnotation",
+            "@context": {"esea": f"{PROJECT_NS}EducationThemeScheme/"},
+        }
+
+    def test_class_without_restriction_stays_simple(self):
+        """A class with no restrictions should not get a scoped context."""
+        snapshot = _make_snapshot(
+            concept_schemes=[_theme_scheme()],
+            classes=[
+                {
+                    "id": str(CLASS_ID),
+                    "identifier": "Investigation",
+                    "label": "Investigation",
+                    "uri": f"{EXTERNAL_NS}Investigation",
+                }
+            ],
+        )
+        ctx = ContextGenerationService().generate(snapshot)["@context"]
+        assert ctx["Investigation"] == "evrepo:Investigation"
+
+    def test_restriction_not_matching_any_scheme(self):
+        """allValuesFrom a type that doesn't appear in any scheme's concepts
+        should not produce a scoped context."""
+        snapshot = _make_snapshot(
+            concept_schemes=[_theme_scheme()],
+            classes=[
+                _annotation_class(value_uri=f"{PROJECT_NS}UnknownConcept"),
+            ],
+        )
+        ctx = ContextGenerationService().generate(snapshot)["@context"]
+        # Falls back to simple mapping
+        assert ctx["EducationThemeCodingAnnotation"] == "esea:EducationThemeCodingAnnotation"
+
+    def test_multiple_annotation_types_each_get_own_scheme(self):
+        """Each annotation type should get a scoped prefix for its own scheme."""
+        doc_scheme_id = UUID("01965a00-0000-7000-8000-000000000003")
+        snapshot = _make_snapshot(
+            concept_schemes=[
+                _theme_scheme(),
+                {
+                    "id": str(doc_scheme_id),
+                    "title": "Document Type",
+                    "uri": f"{PROJECT_NS}DocumentTypeScheme",
+                    "concepts": [
+                        {
+                            "id": "01965a00-0000-7000-8000-000000000097",
+                            "pref_label": "RCT",
+                            "identifier": "C00008",
+                            "uri": f"{PROJECT_NS}DocumentTypeScheme/C00008",
+                            "broader_ids": [],
+                            "related_ids": [],
+                            "alt_labels": [],
+                            "concept_type_uris": [f"{PROJECT_NS}DocumentTypeConcept"],
+                        }
+                    ],
+                },
+            ],
+            classes=[
+                _annotation_class(),
+                {
+                    "id": str(EXT_CLASS_ID),
+                    "identifier": "DocumentTypeCodingAnnotation",
+                    "label": "Document Type Coding Annotation",
+                    "uri": f"{PROJECT_NS}DocumentTypeCodingAnnotation",
+                    "restrictions": [
+                        {
+                            "on_property_uri": f"{EXTERNAL_NS}codedValue",
+                            "restriction_type": "allValuesFrom",
+                            "value_uri": f"{PROJECT_NS}DocumentTypeConcept",
+                        }
+                    ],
+                },
+            ],
+        )
+        ctx = ContextGenerationService().generate(snapshot)["@context"]
+        assert ctx["EducationThemeCodingAnnotation"] == {
+            "@id": "esea:EducationThemeCodingAnnotation",
+            "@context": {"esea": f"{PROJECT_NS}EducationThemeScheme/"},
+        }
+        assert ctx["DocumentTypeCodingAnnotation"] == {
+            "@id": "esea:DocumentTypeCodingAnnotation",
+            "@context": {"esea": f"{PROJECT_NS}DocumentTypeScheme/"},
+        }


### PR DESCRIPTION
## Summary

- Context generation now detects CodingAnnotation classes with `allValuesFrom` OWL restrictions and emits type-scoped prefix redefinitions in `context.jsonld`
- This bridges the URI mismatch where the vocabulary defines `esea:EducationThemeScheme/C00074` but the robot emits `esea:C00074` — the scoped context makes pyld expand the CURIE correctly within typed annotation nodes
- Zero robot changes needed — robot keeps emitting `esea:C00074`, the context handles the expansion
- `@base` approach (option 1) did not work reliably with pyld 2.0.4 — see [gist](https://gist.github.com/jaybea/fdff14d83705ff4e6085bd21fefe1672) for full test results

**Before:**
```json
"EducationThemeCodingAnnotation": "esea:EducationThemeCodingAnnotation"
```

**After:**
```json
"EducationThemeCodingAnnotation": {
    "@id": "esea:EducationThemeCodingAnnotation",
    "@context": { "esea": "https://vocab.esea.education/EducationThemeScheme/" }
}
```

8 annotation types affected (all ESEA CodingAnnotation subclasses with scheme data).

## Validation performed

- 26 unit tests pass (4 new tests for type-scoped prefix redefinition)
- 985 backend tests pass, 0 regressions
- Published ESEA v2.2 locally, verified context.jsonld contains 8 scoped entries
- End-to-end pyld validation: all 8 annotation types expand to correct scheme-scoped URIs
- Robot processed 6,575 refs with updated context — 4,356 enhancements produced, 4,357 LDEs stored in DR after SHACL validation, ~2,219 LinkedRobotErrors (no-outcome refs)