### PR TITLE
Redirect reader domain

### DIFF
--- a/infra/app/frontdoor.tf
+++ b/infra/app/frontdoor.tf
@@ -465,3 +465,83 @@ resource "dnsimple_zone_record" "feedback_validation" {
   value     = azurerm_cdn_frontdoor_custom_domain.feedback.validation_token
   ttl       = 3600
 }
+
+# --- Reader redirect (vocab-reader → vocab) ---
+locals {
+  reader_redirect_domain = var.reader_redirect_subdomain != null ? "${var.reader_redirect_subdomain}.${var.custom_domain}" : null
+}
+
+resource "azurerm_cdn_frontdoor_custom_domain" "reader_redirect" {
+  count                    = var.reader_redirect_subdomain != null ? 1 : 0
+  name                     = replace(local.reader_redirect_domain, ".", "-")
+  cdn_frontdoor_profile_id = data.azurerm_cdn_frontdoor_profile.shared.id
+  host_name                = local.reader_redirect_domain
+
+  tls {
+    certificate_type    = "ManagedCertificate"
+    minimum_tls_version = "TLS12"
+  }
+}
+
+resource "azurerm_cdn_frontdoor_rule_set" "reader_redirect" {
+  count                    = var.reader_redirect_subdomain != null ? 1 : 0
+  name                     = "readerredirect${replace(local.name, "-", "")}"
+  cdn_frontdoor_profile_id = data.azurerm_cdn_frontdoor_profile.shared.id
+}
+
+resource "azurerm_cdn_frontdoor_rule" "reader_redirect" {
+  count                     = var.reader_redirect_subdomain != null ? 1 : 0
+  name                      = "RedirectToReader"
+  cdn_frontdoor_rule_set_id = azurerm_cdn_frontdoor_rule_set.reader_redirect[0].id
+  order                     = 1
+  behavior_on_match         = "Stop"
+
+  actions {
+    url_redirect_action {
+      redirect_type        = "Found"
+      redirect_protocol    = "Https"
+      destination_hostname = local.feedback_custom_domain
+    }
+  }
+}
+
+resource "azurerm_cdn_frontdoor_route" "reader_redirect" {
+  count                         = var.reader_redirect_subdomain != null ? 1 : 0
+  name                          = "rt-reader-redirect-${local.name}"
+  cdn_frontdoor_endpoint_id     = azurerm_cdn_frontdoor_endpoint.this.id
+  cdn_frontdoor_origin_group_id = azurerm_cdn_frontdoor_origin_group.frontend.id
+  cdn_frontdoor_origin_ids      = [azurerm_cdn_frontdoor_origin.frontend.id]
+
+  supported_protocols    = ["Http", "Https"]
+  patterns_to_match      = ["/*"]
+  forwarding_protocol    = "HttpsOnly"
+  link_to_default_domain = false
+  https_redirect_enabled = true
+
+  cdn_frontdoor_custom_domain_ids = [azurerm_cdn_frontdoor_custom_domain.reader_redirect[0].id]
+  cdn_frontdoor_rule_set_ids      = [azurerm_cdn_frontdoor_rule_set.reader_redirect[0].id]
+}
+
+resource "azurerm_cdn_frontdoor_custom_domain_association" "reader_redirect" {
+  count                          = var.reader_redirect_subdomain != null ? 1 : 0
+  cdn_frontdoor_custom_domain_id = azurerm_cdn_frontdoor_custom_domain.reader_redirect[0].id
+  cdn_frontdoor_route_ids        = [azurerm_cdn_frontdoor_route.reader_redirect[0].id]
+}
+
+resource "dnsimple_zone_record" "reader_redirect_cname" {
+  count     = var.reader_redirect_subdomain != null ? 1 : 0
+  zone_name = var.custom_domain
+  name      = var.reader_redirect_subdomain
+  type      = "CNAME"
+  value     = azurerm_cdn_frontdoor_endpoint.this.host_name
+  ttl       = 3600
+}
+
+resource "dnsimple_zone_record" "reader_redirect_validation" {
+  count     = var.reader_redirect_subdomain != null ? 1 : 0
+  zone_name = var.custom_domain
+  name      = "_dnsauth.${var.reader_redirect_subdomain}"
+  type      = "TXT"
+  value     = azurerm_cdn_frontdoor_custom_domain.reader_redirect[0].validation_token
+  ttl       = 3600
+}

--- a/infra/app/frontdoor.tf
+++ b/infra/app/frontdoor.tf
@@ -201,6 +201,10 @@ resource "azurerm_cdn_frontdoor_custom_domain" "feedback" {
     certificate_type    = "ManagedCertificate"
     minimum_tls_version = "TLS12"
   }
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 # Feedback UI SPA — catch-all route on the feedback subdomain
@@ -402,6 +406,10 @@ resource "azurerm_cdn_frontdoor_custom_domain" "this" {
   tls {
     certificate_type    = "ManagedCertificate"
     minimum_tls_version = "TLS12"
+  }
+
+  lifecycle {
+    create_before_destroy = true
   }
 }
 

--- a/infra/app/frontdoor.tf
+++ b/infra/app/frontdoor.tf
@@ -279,6 +279,10 @@ resource "azurerm_cdn_frontdoor_custom_domain_association" "feedback" {
     azurerm_cdn_frontdoor_route.feedback_api.id,
     azurerm_cdn_frontdoor_route.feedback_published.id,
   ]
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 # Cache rule set for feedback UI static assets — purged on deploy
@@ -420,6 +424,10 @@ resource "azurerm_cdn_frontdoor_custom_domain_association" "this" {
     azurerm_cdn_frontdoor_route.api.id,
     azurerm_cdn_frontdoor_route.published.id,
   ]
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 # --- DNS (DNSimple) ---

--- a/infra/app/variables.tf
+++ b/infra/app/variables.tf
@@ -158,6 +158,12 @@ variable "feedback_subdomain" {
   default     = "taxonomy-reader-beta"
 }
 
+variable "reader_redirect_subdomain" {
+  description = "Subdomain to redirect to the reader UI (e.g., vocab-reader.dev), null to disable"
+  type        = string
+  default     = null
+}
+
 variable "cache_feedback_ui_at_edge" {
   description = "Enable Front Door edge caching for the feedback UI (disable for testing)"
   type        = bool


### PR DESCRIPTION
Spike PR for #187 

Includes `create_before_destroy` directives for one-off migration ordering, and an optional redirect rule for the reader domain.

Deployed & working in dev: https://vocab-reader.dev.evidence-repository.org/