### PR TITLE
Extend unresolved feedback count docs

### DIFF
--- a/backend/src/taxonomy_builder/api/feedback.py
+++ b/backend/src/taxonomy_builder/api/feedback.py
@@ -32,12 +32,12 @@ feedback_router = APIRouter(prefix="/api/feedback", tags=["feedback"])
 @feedback_router.get(
     "/counts",
 )
-async def get_open_counts(
+async def get_unresolved_counts(
     project_ids: list[UUID] = Query(...),
     service: FeedbackService = Depends(get_manager_feedback_service),
 ) -> dict[str, int]:
-    """Open + responded feedback counts per project for badge display."""
-    counts = await service.get_open_counts(project_ids)
+    """Unresolved (open + responded) feedback counts per project for badges."""
+    counts = await service.get_unresolved_counts(project_ids)
     return {str(k): v for k, v in counts.items()}
 
 

--- a/backend/src/taxonomy_builder/mcp/tools.py
+++ b/backend/src/taxonomy_builder/mcp/tools.py
@@ -487,9 +487,7 @@ async def update_concepts_batch(
         try:
             UUID(u["concept_id"])
         except ValueError:
-            return (
-                f"Invalid concept_id {u['concept_id']!r} at [{i}]: not a valid UUID."
-            )
+            return f"Invalid concept_id {u['concept_id']!r} at [{i}]: not a valid UUID."
 
     updated = []
     for u in updates:
@@ -585,9 +583,7 @@ async def check_quality(
     missing_scope = [c for c in concepts if not c.scope_note]
     if missing_scope:
         labels = ", ".join(c.pref_label for c in missing_scope[:10])
-        suffix = (
-            f" (and {len(missing_scope) - 10} more)" if len(missing_scope) > 10 else ""
-        )
+        suffix = f" (and {len(missing_scope) - 10} more)" if len(missing_scope) > 10 else ""
         issues.append(f"Missing scope notes ({len(missing_scope)}): {labels}{suffix}")
 
     label_counts: dict[str, list[str]] = {}
@@ -597,9 +593,7 @@ async def check_quality(
     dupes = {k: v for k, v in label_counts.items() if len(v) > 1}
     if dupes:
         for label, instances in dupes.items():
-            issues.append(
-                f"Duplicate label: '{instances[0]}' appears {len(instances)} times"
-            )
+            issues.append(f"Duplicate label: '{instances[0]}' appears {len(instances)} times")
 
     pref_labels_lower = {c.pref_label.lower(): c.pref_label for c in concepts}
     for c in concepts:
@@ -658,9 +652,7 @@ async def get_history(
             entity_label = f" '{event.after_state['pref_label']}'"
         elif event.before_state and "pref_label" in event.before_state:
             entity_label = f" '{event.before_state['pref_label']}'"
-        lines.append(
-            f"  [{ts}] {user_name}: {event.action} {event.entity_type}{entity_label}"
-        )
+        lines.append(f"  [{ts}] {user_name}: {event.action} {event.entity_type}{entity_label}")
     return "\n".join(lines)
 
 
@@ -748,9 +740,9 @@ async def get_feedback_counts(
     project_svc: ProjectService = Depends(get_project_service),
     feedback_svc: FeedbackService = Depends(get_feedback_service),
 ) -> str:
-    """Get open feedback counts for all projects.
+    """Get unresolved feedback counts for all projects.
 
-    Shows how many unresolved feedback items exist per project,
+    Shows how many feedback items with status "open" or "responded" exist per project,
     useful for prioritising triage work.
     """
     projects = await project_svc.list_projects()

--- a/backend/src/taxonomy_builder/mcp/tools.py
+++ b/backend/src/taxonomy_builder/mcp/tools.py
@@ -748,7 +748,7 @@ async def get_feedback_counts(
     projects = await project_svc.list_projects()
     if not projects:
         return "No projects found."
-    counts = await feedback_svc.get_open_counts([p.id for p in projects])
+    counts = await feedback_svc.get_unresolved_counts([p.id for p in projects])
 
     lines = ["Open feedback counts:"]
     for p in projects:

--- a/backend/src/taxonomy_builder/services/feedback_service.py
+++ b/backend/src/taxonomy_builder/services/feedback_service.py
@@ -271,10 +271,15 @@ class FeedbackService:
     ) -> Feedback:
         return await self._triage(feedback_id, FeedbackStatus.declined, content)
 
-    async def get_open_counts(
+    async def get_unresolved_counts(
         self, project_ids: list[UUID]
     ) -> dict[UUID, int]:
-        """Open + responded counts per project for badge display."""
+        """Counts per project of feedback with status ``open`` or ``responded``.
+
+        Excludes ``resolved`` and ``declined``. Used for badge display and to
+        prioritise triage. Soft-deleted feedback (``deleted_at IS NOT NULL``)
+        is also excluded.
+        """
         result = await self.db.execute(
             select(Feedback.project_id, func.count())
             .where(


### PR DESCRIPTION
Noticed while playing around with the MCP - Claude got confused when `len(list(status=open))` != open feedback count! This PR makes it clear to the LLM that unresolved = open + responded.