### PR TITLE
Add full content and entity ids to feedback tools

### DIFF
--- a/backend/src/taxonomy_builder/mcp/formatters.py
+++ b/backend/src/taxonomy_builder/mcp/formatters.py
@@ -86,7 +86,9 @@ def format_concept_brief(concept) -> str:
 def format_feedback(feedback) -> str:
     lines = [
         f"[{feedback.status}] \"{feedback.feedback_type}\" on"
-        f" {feedback.entity_type} '{feedback.entity_label}' (id: {feedback.id})",
+        f" {feedback.entity_type} '{feedback.entity_label}'"
+        f" ({feedback.entity_type}_id: {feedback.entity_id})"
+        f" (feedback_id: {feedback.id})",
         f"  By: {feedback.author_name} ({feedback.created_at})",
         f"  Content: {feedback.content}",
     ]
@@ -100,7 +102,8 @@ def format_feedback(feedback) -> str:
 def format_feedback_brief(feedback) -> str:
     return (
         f"[{feedback.status}] {feedback.entity_type} '{feedback.entity_label}'"
-        f" — {feedback.feedback_type} (id: {feedback.id})"
+        f" ({feedback.entity_type}_id: {feedback.entity_id})"
+        f" — {feedback.feedback_type} (feedback_id: {feedback.id})"
     )
 
 

--- a/backend/src/taxonomy_builder/mcp/tools.py
+++ b/backend/src/taxonomy_builder/mcp/tools.py
@@ -31,7 +31,10 @@ from taxonomy_builder.schemas.concept_scheme import (
 from taxonomy_builder.schemas.project import ProjectCreate
 from taxonomy_builder.services.concept_scheme_service import ConceptSchemeService
 from taxonomy_builder.services.concept_service import ConceptService
-from taxonomy_builder.services.feedback_service import FeedbackService
+from taxonomy_builder.services.feedback_service import (
+    FeedbackNotFoundError,
+    FeedbackService,
+)
 from taxonomy_builder.services.history_service import HistoryService
 from taxonomy_builder.services.project_service import ProjectService
 from taxonomy_builder.services.skos_export_service import SKOSExportService
@@ -766,6 +769,23 @@ async def get_feedback_counts(
     if len(lines) == 1:
         return "No open feedback across any project."
     return "\n".join(lines)
+
+
+@mcp.tool(auth=_auth)
+async def get_feedback(
+    feedback_id: str,
+    svc: FeedbackService = Depends(get_feedback_service),
+) -> str:
+    """Get full details of a single feedback item.
+
+    Args:
+        feedback_id: UUID of the feedback item
+    """
+    try:
+        fb = await svc.get(UUID(feedback_id))
+    except FeedbackNotFoundError:
+        return f"Feedback '{feedback_id}' not found."
+    return format_feedback(fb)
 
 
 @mcp.tool(auth=_auth)

--- a/backend/src/taxonomy_builder/services/feedback_service.py
+++ b/backend/src/taxonomy_builder/services/feedback_service.py
@@ -106,7 +106,7 @@ class FeedbackService:
             raise VersionNotFoundError(project_id, version)
         return pv
 
-    async def _get_feedback(self, feedback_id: UUID) -> Feedback:
+    async def get(self, feedback_id: UUID) -> Feedback:
         """Load a non-deleted feedback by ID or raise."""
         result = await self.db.execute(
             select(Feedback).where(
@@ -240,7 +240,7 @@ class FeedbackService:
 
     async def respond(self, feedback_id: UUID, content: str) -> Feedback:
         """Add response. Allowed when open/responded. 409 if resolved/declined."""
-        fb = await self._get_feedback(feedback_id)
+        fb = await self.get(feedback_id)
         if fb.status in (FeedbackStatus.resolved.value, FeedbackStatus.declined.value):
             raise FeedbackStatusConflictError(feedback_id, fb.status, "respond to")
         self._set_response(fb, content)
@@ -252,7 +252,7 @@ class FeedbackService:
         self, feedback_id: UUID, new_status: FeedbackStatus, content: str | None,
     ) -> Feedback:
         """Set status to resolved/declined, optionally attaching a response."""
-        fb = await self._get_feedback(feedback_id)
+        fb = await self.get(feedback_id)
         fb.status = new_status.value
         fb.status_changed_at = datetime.now()
         fb.status_changed_by = self.user_id

--- a/backend/tests/test_mcp/test_formatters.py
+++ b/backend/tests/test_mcp/test_formatters.py
@@ -215,6 +215,7 @@ class FakeFeedback:
         id="019fb",
         status="open",
         entity_type="concept",
+        entity_id="019concept",
         entity_label="Dogs",
         feedback_type="unclear_definition",
         content="The definition is vague",
@@ -226,6 +227,7 @@ class FakeFeedback:
         self.id = id
         self.status = status
         self.entity_type = entity_type
+        self.entity_id = entity_id
         self.entity_label = entity_label
         self.feedback_type = feedback_type
         self.content = content
@@ -245,6 +247,7 @@ class TestFormatFeedback:
         assert "The definition is vague" in result
         assert "Reviewer User" in result
         assert "019fb" in result
+        assert "019concept" in result
 
     def test_with_response(self):
         fb = FakeFeedback(
@@ -270,3 +273,4 @@ class TestFormatFeedbackBrief:
         assert "concept" in result
         assert "Dogs" in result
         assert "019fb" in result
+        assert "019concept" in result

--- a/backend/tests/test_mcp/test_tools.py
+++ b/backend/tests/test_mcp/test_tools.py
@@ -674,6 +674,29 @@ class TestListFeedback:
         assert "1 item" in result
 
 
+class TestGetFeedback:
+    async def test_basic(
+        self, db_session: AsyncSession, project: Project, test_user: User,
+        feedback_svc: FeedbackService,
+    ):
+        fb = _make_feedback(project, test_user)
+        db_session.add(fb)
+        await db_session.flush()
+
+        result = await tools.get_feedback(str(fb.id), svc=feedback_svc)
+        assert "Test Concept" in result
+        assert "The definition is unclear" in result
+        assert str(fb.id) in result
+
+    async def test_not_found(
+        self, feedback_svc: FeedbackService,
+    ):
+        result = await tools.get_feedback(
+            "00000000-0000-0000-0000-000000000000", svc=feedback_svc,
+        )
+        assert "not found" in result.lower()
+
+
 class TestRespondToFeedback:
     async def test_basic(
         self, db_session: AsyncSession, project: Project, test_user: User,


### PR DESCRIPTION
The `list_feedback` tool does indeed list all the feedback, but doesn't have an entity id to go back to. Similarly, it doesn't include the content of the feedback.

This PR adds the entity id to the `list_feedback` tool, and adds a `get_feedback` tool which gives the whole feedback content to the client.