### PR TITLE
Make it easier for LLM's to triage feedback

### DIFF
--- a/backend/src/taxonomy_builder/mcp/tools.py
+++ b/backend/src/taxonomy_builder/mcp/tools.py
@@ -3,6 +3,8 @@
 from uuid import UUID
 
 from fastmcp.dependencies import Depends
+from fastmcp.tools import ToolResult
+from mcp.types import TextContent
 
 from taxonomy_builder.config import settings
 from taxonomy_builder.mcp.dependencies import (
@@ -796,7 +798,7 @@ async def list_feedback(
     feedback_type: str | None = None,
     query: str | None = None,
     svc: FeedbackService = Depends(get_feedback_service),
-) -> str:
+) -> ToolResult:
     """List feedback for a project with optional filters.
 
     Args:
@@ -814,11 +816,17 @@ async def list_feedback(
         q=query,
     )
     if not items:
-        return "No feedback found."
+        return ToolResult(
+            content=[TextContent(type="text", text="No feedback found.")],
+            structured_content={"feedback": []},
+        )
     lines = [f"Feedback ({len(items)} item(s)):"]
     for fb in items:
         lines.append(f"  {format_feedback_brief(fb)}")
-    return "\n".join(lines)
+    return ToolResult(
+        content=[TextContent(type="text", text="\n".join(lines))],
+        structured_content={"feedback": [fb.to_manager_dict() for fb in items]},
+    )
 
 
 @mcp.tool(auth=_auth)

--- a/backend/src/taxonomy_builder/mcp/tools.py
+++ b/backend/src/taxonomy_builder/mcp/tools.py
@@ -830,6 +830,40 @@ async def list_feedback(
 
 
 @mcp.tool(auth=_auth)
+async def export_feedback(
+    project_id: str,
+    status: str | None = None,
+    entity_type: str | None = None,
+    feedback_type: str | None = None,
+    svc: FeedbackService = Depends(get_feedback_service),
+) -> ToolResult:
+    """Export all feedback for a project as structured JSON.
+
+    Returns full details of every matching feedback item in
+    structuredContent, avoiding the need for individual get_feedback calls.
+
+    Args:
+        project_id: UUID of the project
+        status: Filter by status — "open", "responded", "resolved", or "declined"
+        entity_type: Filter by entity type — "concept", "scheme", "ontology_class", or "property"
+        feedback_type: Filter by feedback type (e.g. "unclear_definition", "missing_term")
+    """
+    items = await svc.list_all(
+        UUID(project_id),
+        status=status,
+        entity_type=entity_type,
+        feedback_type=feedback_type,
+    )
+    return ToolResult(
+        content=[TextContent(
+            type="text",
+            text=f"{len(items)} feedback item(s) exported.",
+        )],
+        structured_content={"feedback": [fb.to_manager_dict() for fb in items]},
+    )
+
+
+@mcp.tool(auth=_auth)
 async def respond_to_feedback(
     feedback_id: str,
     content: str,

--- a/backend/tests/test_mcp/test_tools.py
+++ b/backend/tests/test_mcp/test_tools.py
@@ -647,7 +647,8 @@ class TestListFeedback:
         self, project: Project, feedback_svc: FeedbackService,
     ):
         result = await tools.list_feedback(str(project.id), svc=feedback_svc)
-        assert "No feedback found" in result
+        assert "No feedback found" in result.content[0].text
+        assert result.structured_content == {"feedback": []}
 
     async def test_with_feedback(
         self, db_session: AsyncSession, project: Project, test_user: User,
@@ -657,8 +658,15 @@ class TestListFeedback:
         await db_session.flush()
 
         result = await tools.list_feedback(str(project.id), svc=feedback_svc)
-        assert "1 item" in result
-        assert "Test Concept" in result
+        text = result.content[0].text
+        assert "1 item" in text
+        assert "Test Concept" in text
+        # structured_content is a JSON list of feedback dicts
+        assert result.structured_content is not None
+        items = result.structured_content["feedback"]
+        assert len(items) == 1
+        assert items[0]["entity_label"] == "Test Concept"
+        assert items[0]["entity_id"] == "fake-entity-id"
 
     async def test_filter_by_status(
         self, db_session: AsyncSession, project: Project, test_user: User,
@@ -671,7 +679,8 @@ class TestListFeedback:
         result = await tools.list_feedback(
             str(project.id), status="open", svc=feedback_svc,
         )
-        assert "1 item" in result
+        assert "1 item" in result.content[0].text
+        assert len(result.structured_content["feedback"]) == 1
 
 
 class TestGetFeedback:

--- a/backend/tests/test_mcp/test_tools.py
+++ b/backend/tests/test_mcp/test_tools.py
@@ -706,6 +706,45 @@ class TestGetFeedback:
         assert "not found" in result.lower()
 
 
+class TestExportFeedback:
+    async def test_empty(
+        self, project: Project, feedback_svc: FeedbackService,
+    ):
+        result = await tools.export_feedback(str(project.id), svc=feedback_svc)
+        assert result.structured_content == {"feedback": []}
+        assert result.content[0].text == "0 feedback item(s) exported."
+
+    async def test_exports_full_details(
+        self, db_session: AsyncSession, project: Project, test_user: User,
+        feedback_svc: FeedbackService,
+    ):
+        db_session.add(_make_feedback(project, test_user, content="First issue"))
+        db_session.add(_make_feedback(project, test_user, content="Second issue"))
+        await db_session.flush()
+
+        result = await tools.export_feedback(str(project.id), svc=feedback_svc)
+        assert result.content[0].text == "2 feedback item(s) exported."
+        items = result.structured_content["feedback"]
+        assert len(items) == 2
+        # Full detail fields present
+        assert "content" in items[0]
+        assert "entity_id" in items[0]
+        assert "author_name" in items[0]
+
+    async def test_filter_by_status(
+        self, db_session: AsyncSession, project: Project, test_user: User,
+        feedback_svc: FeedbackService,
+    ):
+        db_session.add(_make_feedback(project, test_user, status="open"))
+        db_session.add(_make_feedback(project, test_user, status="resolved"))
+        await db_session.flush()
+
+        result = await tools.export_feedback(
+            str(project.id), status="open", svc=feedback_svc,
+        )
+        assert len(result.structured_content["feedback"]) == 1
+
+
 class TestRespondToFeedback:
     async def test_basic(
         self, db_session: AsyncSession, project: Project, test_user: User,


### PR DESCRIPTION
Adds a structured response to `list_feedback` which allows LLMs to more easily aggregate the data.

Also adds an `export_feedback` tool which allows dumping of the full content of feedback quickly (saving `get_feedback` roundtrips)