### PR TITLE
Add Matomo analytics to frontend and feedback-ui

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -152,6 +152,7 @@ jobs:
           VITE_KEYCLOAK_REALM: ${{ vars.KEYCLOAK_REALM }}
           VITE_KEYCLOAK_CLIENT_ID: ${{ vars.KEYCLOAK_CLIENT_ID }}
           VITE_FEEDBACK_URL: ${{ vars.FEEDBACK_URL }}
+          VITE_MATOMO_CONTAINER_URL: ${{ vars.MATOMO_CONTAINER_URL }}
         run: npm run build
 
       - name: Upload frontend artifacts
@@ -191,6 +192,7 @@ jobs:
           VITE_KEYCLOAK_URL: ${{ vars.KEYCLOAK_URL }}
           VITE_KEYCLOAK_REALM: ${{ vars.KEYCLOAK_REALM }}
           VITE_KEYCLOAK_CLIENT_ID: ${{ vars.KEYCLOAK_FEEDBACK_CLIENT_ID }}
+          VITE_MATOMO_CONTAINER_URL: ${{ vars.MATOMO_FEEDBACK_CONTAINER_URL }}
         run: npm run build
 
       - name: Upload feedback UI artifacts

--- a/feedback-ui/src/analytics/matomo.ts
+++ b/feedback-ui/src/analytics/matomo.ts
@@ -1,0 +1,23 @@
+declare global {
+  interface Window {
+    _mtm?: Array<Record<string, unknown>>;
+  }
+}
+
+export function initMatomo(containerUrl: string | undefined): void {
+  if (!containerUrl) return;
+  if (document.querySelector(`script[src="${containerUrl}"]`)) return;
+
+  window._mtm = window._mtm || [];
+  window._mtm.push({ "mtm.startTime": Date.now(), event: "mtm.Start" });
+
+  const script = document.createElement("script");
+  script.async = true;
+  script.src = containerUrl;
+  const firstScript = document.getElementsByTagName("script")[0];
+  if (firstScript?.parentNode) {
+    firstScript.parentNode.insertBefore(script, firstScript);
+  } else {
+    document.head.appendChild(script);
+  }
+}

--- a/feedback-ui/src/analytics/matomo.ts
+++ b/feedback-ui/src/analytics/matomo.ts
@@ -6,18 +6,13 @@ declare global {
 
 export function initMatomo(containerUrl: string | undefined): void {
   if (!containerUrl) return;
-  if (document.querySelector(`script[src="${containerUrl}"]`)) return;
 
-  window._mtm = window._mtm || [];
-  window._mtm.push({ "mtm.startTime": Date.now(), event: "mtm.Start" });
+  const _mtm = (window._mtm = window._mtm || []);
+  _mtm.push({ "mtm.startTime": new Date().getTime(), event: "mtm.Start" });
 
-  const script = document.createElement("script");
-  script.async = true;
-  script.src = containerUrl;
-  const firstScript = document.getElementsByTagName("script")[0];
-  if (firstScript?.parentNode) {
-    firstScript.parentNode.insertBefore(script, firstScript);
-  } else {
-    document.head.appendChild(script);
-  }
+  const g = document.createElement("script");
+  const s = document.getElementsByTagName("script")[0];
+  g.async = true;
+  g.src = containerUrl;
+  s.parentNode!.insertBefore(g, s);
 }

--- a/feedback-ui/src/config.ts
+++ b/feedback-ui/src/config.ts
@@ -1,2 +1,3 @@
 export const API_BASE = import.meta.env.VITE_API_BASE || "/api";
 export const PUBLISHED_BASE = import.meta.env.VITE_PUBLISHED_BASE || "/published";
+export const MATOMO_CONTAINER_URL = import.meta.env.VITE_MATOMO_CONTAINER_URL;

--- a/feedback-ui/src/main.tsx
+++ b/feedback-ui/src/main.tsx
@@ -1,8 +1,11 @@
 import { render } from "preact";
 import { App } from "./App";
+import { initMatomo } from "./analytics/matomo";
+import { MATOMO_CONTAINER_URL } from "./config";
 import { registerServiceWorker } from "./sw-register";
 import "./styles/variables.css";
 import "./styles/reset.css";
 
 registerServiceWorker();
+initMatomo(MATOMO_CONTAINER_URL);
 render(<App />, document.getElementById("app")!);

--- a/feedback-ui/src/vite-env.d.ts
+++ b/feedback-ui/src/vite-env.d.ts
@@ -6,6 +6,7 @@ interface ImportMetaEnv {
   readonly VITE_KEYCLOAK_URL?: string;
   readonly VITE_KEYCLOAK_REALM?: string;
   readonly VITE_KEYCLOAK_CLIENT_ID?: string;
+  readonly VITE_MATOMO_CONTAINER_URL?: string;
 }
 
 interface ImportMeta {

--- a/frontend/src/analytics/matomo.ts
+++ b/frontend/src/analytics/matomo.ts
@@ -1,0 +1,23 @@
+declare global {
+  interface Window {
+    _mtm?: Array<Record<string, unknown>>;
+  }
+}
+
+export function initMatomo(containerUrl: string | undefined): void {
+  if (!containerUrl) return;
+  if (document.querySelector(`script[src="${containerUrl}"]`)) return;
+
+  window._mtm = window._mtm || [];
+  window._mtm.push({ "mtm.startTime": Date.now(), event: "mtm.Start" });
+
+  const script = document.createElement("script");
+  script.async = true;
+  script.src = containerUrl;
+  const firstScript = document.getElementsByTagName("script")[0];
+  if (firstScript?.parentNode) {
+    firstScript.parentNode.insertBefore(script, firstScript);
+  } else {
+    document.head.appendChild(script);
+  }
+}

--- a/frontend/src/analytics/matomo.ts
+++ b/frontend/src/analytics/matomo.ts
@@ -6,18 +6,13 @@ declare global {
 
 export function initMatomo(containerUrl: string | undefined): void {
   if (!containerUrl) return;
-  if (document.querySelector(`script[src="${containerUrl}"]`)) return;
 
-  window._mtm = window._mtm || [];
-  window._mtm.push({ "mtm.startTime": Date.now(), event: "mtm.Start" });
+  const _mtm = (window._mtm = window._mtm || []);
+  _mtm.push({ "mtm.startTime": new Date().getTime(), event: "mtm.Start" });
 
-  const script = document.createElement("script");
-  script.async = true;
-  script.src = containerUrl;
-  const firstScript = document.getElementsByTagName("script")[0];
-  if (firstScript?.parentNode) {
-    firstScript.parentNode.insertBefore(script, firstScript);
-  } else {
-    document.head.appendChild(script);
-  }
+  const g = document.createElement("script");
+  const s = document.getElementsByTagName("script")[0];
+  g.async = true;
+  g.src = containerUrl;
+  s.parentNode!.insertBefore(g, s);
 }

--- a/frontend/src/config.ts
+++ b/frontend/src/config.ts
@@ -2,3 +2,4 @@ export const API_BASE = import.meta.env.VITE_API_BASE || "/api";
 export const FEEDBACK_URL =
   import.meta.env.VITE_FEEDBACK_URL ||
   (import.meta.env.DEV ? "http://localhost:3001" : "");
+export const MATOMO_CONTAINER_URL = import.meta.env.VITE_MATOMO_CONTAINER_URL;

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,6 +1,9 @@
 import { render } from "preact";
 import { App } from "./App";
+import { initMatomo } from "./analytics/matomo";
+import { MATOMO_CONTAINER_URL } from "./config";
 import "./styles/reset.css";
 import "./styles/variables.css";
 
+initMatomo(MATOMO_CONTAINER_URL);
 render(<App />, document.getElementById("app")!);

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -3,6 +3,7 @@
 interface ImportMetaEnv {
   readonly VITE_API_BASE?: string;
   readonly VITE_FEEDBACK_URL?: string;
+  readonly VITE_MATOMO_CONTAINER_URL?: string;
 }
 
 interface ImportMeta {

--- a/infra/app/github_actions.tf
+++ b/infra/app/github_actions.tf
@@ -223,6 +223,20 @@ resource "github_actions_environment_variable" "keycloak_feedback_client_id" {
   value         = "taxonomy-reader-ui-${var.environment}"
 }
 
+resource "github_actions_environment_variable" "matomo_container_url" {
+  repository    = github_repository_environment.environment.repository
+  environment   = github_repository_environment.environment.environment
+  variable_name = "MATOMO_CONTAINER_URL"
+  value         = var.matomo_frontend_container_url
+}
+
+resource "github_actions_environment_variable" "matomo_feedback_container_url" {
+  repository    = github_repository_environment.environment.repository
+  environment   = github_repository_environment.environment.environment
+  variable_name = "MATOMO_FEEDBACK_CONTAINER_URL"
+  value         = var.matomo_feedback_container_url
+}
+
 # Feedback UI deployment variables
 
 resource "github_actions_environment_variable" "feedback_storage_account_name" {

--- a/infra/app/github_actions.tf
+++ b/infra/app/github_actions.tf
@@ -223,7 +223,11 @@ resource "github_actions_environment_variable" "keycloak_feedback_client_id" {
   value         = "taxonomy-reader-ui-${var.environment}"
 }
 
+# Skipped when empty: GitHub's API rejects empty env-var values, and an
+# absent variable is read by the workflow as "" — which the app's
+# initMatomo() already treats as the no-op signal.
 resource "github_actions_environment_variable" "matomo_container_url" {
+  count         = var.matomo_frontend_container_url != "" ? 1 : 0
   repository    = github_repository_environment.environment.repository
   environment   = github_repository_environment.environment.environment
   variable_name = "MATOMO_CONTAINER_URL"
@@ -231,6 +235,7 @@ resource "github_actions_environment_variable" "matomo_container_url" {
 }
 
 resource "github_actions_environment_variable" "matomo_feedback_container_url" {
+  count         = var.matomo_feedback_container_url != "" ? 1 : 0
   repository    = github_repository_environment.environment.repository
   environment   = github_repository_environment.environment.environment
   variable_name = "MATOMO_FEEDBACK_CONTAINER_URL"

--- a/infra/app/variables.tf
+++ b/infra/app/variables.tf
@@ -181,3 +181,16 @@ variable "dnsimple_account_id" {
   description = "DNSimple account ID"
   type        = string
 }
+
+# Matomo Tag Manager container URLs (per environment, per app)
+variable "matomo_frontend_container_url" {
+  description = "Matomo Tag Manager container URL for the frontend; empty disables analytics"
+  type        = string
+  default     = ""
+}
+
+variable "matomo_feedback_container_url" {
+  description = "Matomo Tag Manager container URL for the feedback UI; empty disables analytics"
+  type        = string
+  default     = ""
+}


### PR DESCRIPTION
Closes #186.

## Summary

- Adds a tiny `src/analytics/matomo.ts` module to both `frontend` and `feedback-ui` that mirrors Matomo's official Tag Manager snippet. No-ops when `VITE_MATOMO_CONTAINER_URL` is empty/unset.
- Wires `initMatomo(MATOMO_CONTAINER_URL)` into each app's `main.tsx` boot sequence.
- Plumbs the per-app, per-env container URLs through Terraform (`matomo_frontend_container_url`, `matomo_feedback_container_url`) and `.github/workflows/deploy.yml` (new `VITE_MATOMO_CONTAINER_URL` for both build jobs).

## Privacy posture (Path A — anonymous, no consent banner)

Cookieless tracking + IP anonymisation + DoNotTrack + no `setUserId` are all configured on the Matomo Tracker tag inside MTM, not in app code. SPA route changes are picked up by MTM's History Change trigger (preact-router uses `pushState`).

## Operational notes

- Each app gets its own Matomo site **and** its own MTM container. Each container has three published versions (`dev`, `staging`, `production`); Matomo Cloud serves them at `container_<id>{,_dev_<hash>,_staging_<hash>}.js`.
- After `terraform apply` per environment, set `matomo_frontend_container_url` and `matomo_feedback_container_url` to the env-appropriate container URLs. Defaults are `""` so envs without containers configured remain unaffected.
- Companion work for `evidence-repo-ui` is tracked in destiny-evidence/evidence-repo-ui#28 and will land as a separate PR.

## Test plan

- [x] `npm run typecheck && npm run build` passes in both `frontend/` and `feedback-ui/`.
- [x] With `VITE_MATOMO_CONTAINER_URL` set to a dev container URL: container script loads, Matomo dev environment shows visits.
- [x] With `VITE_MATOMO_CONTAINER_URL` unset: no script request, no console errors, `window._mtm` undefined.
- [x] MTM Preview/Debug confirms Page View + History Change triggers fire correctly through preact-router navigation.