### PR TITLE
Declare Microsoft.Storage service endpoint on the DB subnet

### DIFF
--- a/infra/app/network.tf
+++ b/infra/app/network.tf
@@ -22,6 +22,10 @@ resource "azurerm_subnet" "db" {
   virtual_network_name = azurerm_virtual_network.this.name
   address_prefixes     = ["10.0.2.0/24"]
 
+  # Required by PostgreSQL flexible server for WAL upload to Azure Storage.
+  # https://learn.microsoft.com/en-us/azure/postgresql/network/concepts-networking-private
+  service_endpoints = ["Microsoft.Storage"]
+
   delegation {
     name = "fs"
     service_delegation {


### PR DESCRIPTION
## Summary

Adds `service_endpoints = ["Microsoft.Storage"]` to the DB subnet at `infra/app/network.tf`. This is required by Azure Database for PostgreSQL flexible server for uploading Write-Ahead Log (WAL) files to Azure Storage — Microsoft auto-adds it on first server provision, and Microsoft Learn warns:

> The Microsoft.Storage service endpoint is automatically configured on the delegated subnet when the first server is provisioned in that subnet. This configuration ensures reliable routing of traffic to the Azure Storage accounts used for uploading Write-Ahead Log (WAL) files. **Removing this endpoint may disrupt connectivity** and can lead to unintended consequences for core service operations.

Source: https://learn.microsoft.com/en-us/azure/postgresql/network/concepts-networking-private
